### PR TITLE
Rely on event & log streams of Liquid SDK plugin

### DIFF
--- a/lib/bloc/account/account_state_assembler.dart
+++ b/lib/bloc/account/account_state_assembler.dart
@@ -10,21 +10,21 @@ import 'account_state.dart';
 AccountState? assembleAccountState(
   List<Payment>? payments,
   PaymentFilters paymentFilters,
-  GetInfoResponse? nodeState,
+  GetInfoResponse? walletInfo,
   AccountState state,
 ) {
-  if (nodeState == null) {
+  if (walletInfo == null) {
     return null;
   }
 
   final texts = getSystemAppLocalizations();
   // return the new account state
   return state.copyWith(
-    id: nodeState.pubkey,
+    id: walletInfo.pubkey,
     initial: false,
-    balance: nodeState.balanceSat.toInt(),
-    pendingReceive: nodeState.pendingReceiveSat.toInt(),
-    pendingSend: nodeState.pendingSendSat.toInt(),
+    balance: walletInfo.balanceSat.toInt(),
+    pendingReceive: walletInfo.pendingReceiveSat.toInt(),
+    pendingSend: walletInfo.pendingSendSat.toInt(),
     maxPaymentAmount: maxPaymentAmount,
     onChainFeeRate: 0,
     payments: payments?.map((e) => PaymentMinutiae.fromPayment(e, texts)).toList(),

--- a/lib/bloc/account/breez_liquid_sdk.dart
+++ b/lib/bloc/account/breez_liquid_sdk.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
+import 'package:rxdart/rxdart.dart';
+
+class BreezLiquidSDK {
+  liquid_sdk.BindingLiquidSdk? wallet;
+
+  Future<liquid_sdk.BindingLiquidSdk> connect({
+    required liquid_sdk.ConnectRequest req,
+  }) async {
+    wallet = await liquid_sdk.connect(req: req);
+    _initializeEventsStream(wallet!);
+    _subscribeToSdkStreams(wallet!);
+    await _fetchWalletData(wallet!);
+    return wallet!;
+  }
+
+  void disconnect(liquid_sdk.BindingLiquidSdk sdk) {
+    sdk.disconnect();
+    _unsubscribeFromSdkStreams();
+  }
+
+  Future _fetchWalletData(liquid_sdk.BindingLiquidSdk sdk) async {
+    await _getInfo(sdk);
+    await _listPayments(sdk);
+  }
+
+  Future<liquid_sdk.GetInfoResponse> _getInfo(liquid_sdk.BindingLiquidSdk sdk) async {
+    final walletInfo = await sdk.getInfo();
+    _walletInfoController.add(walletInfo);
+    return walletInfo;
+  }
+
+  Future<List<liquid_sdk.Payment>> _listPayments(liquid_sdk.BindingLiquidSdk sdk) async {
+    final paymentsList = await sdk.listPayments();
+    _paymentsController.add(paymentsList);
+    return paymentsList;
+  }
+
+  StreamSubscription<liquid_sdk.LogEntry>? _breezLogSubscription;
+
+  Stream<liquid_sdk.LogEntry>? _breezLogStream;
+
+  /// Initializes SDK log stream.
+  ///
+  /// Call once on your Dart entrypoint file, e.g.; `lib/main.dart`.
+  void initializeLogStream() {
+    _breezLogStream ??= liquid_sdk.breezLogStream().asBroadcastStream();
+  }
+
+  StreamSubscription<liquid_sdk.LiquidSdkEvent>? _breezEventsSubscription;
+
+  Stream<liquid_sdk.LiquidSdkEvent>? _breezEventsStream;
+
+  void _initializeEventsStream(liquid_sdk.BindingLiquidSdk sdk) {
+    _breezEventsStream ??= sdk.addEventListener().asBroadcastStream();
+  }
+
+  /// Subscribes to SDK's event & log streams.
+  void _subscribeToSdkStreams(liquid_sdk.BindingLiquidSdk sdk) {
+    _subscribeToEventsStream(sdk);
+    _subscribeToLogStream();
+  }
+
+  final StreamController<liquid_sdk.GetInfoResponse> _walletInfoController =
+      BehaviorSubject<liquid_sdk.GetInfoResponse>();
+
+  Stream<liquid_sdk.GetInfoResponse> get walletInfoStream => _walletInfoController.stream;
+
+  final StreamController<liquid_sdk.Payment> _paymentResultStream = StreamController.broadcast();
+
+  final StreamController<List<liquid_sdk.Payment>> _paymentsController =
+      BehaviorSubject<List<liquid_sdk.Payment>>();
+
+  Stream<List<liquid_sdk.Payment>> get paymentsStream => _paymentsController.stream;
+
+  Stream<liquid_sdk.Payment> get paymentResultStream => _paymentResultStream.stream;
+
+  /* TODO: Liquid - Log statements are added for debugging purposes, should be removed after early development stage is complete & events are behaving as expected.*/
+  /// Subscribes to LiquidSdkEvent's stream
+  void _subscribeToEventsStream(liquid_sdk.BindingLiquidSdk sdk) {
+    _breezEventsSubscription = _breezEventsStream?.listen(
+      (event) async {
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentFailed) {
+          _logStreamController
+              .add(liquid_sdk.LogEntry(line: "Payment Failed. ${event.details.swapId}", level: "WARN"));
+          _paymentResultStream.addError(PaymentException(event.details));
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentPending) {
+          _logStreamController
+              .add(liquid_sdk.LogEntry(line: "Payment Pending. ${event.details.swapId}", level: "INFO"));
+          _paymentResultStream.add(event.details);
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentRefunded) {
+          _logStreamController
+              .add(liquid_sdk.LogEntry(line: "Payment Refunded. ${event.details.swapId}", level: "INFO"));
+          _paymentResultStream.add(event.details);
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentRefundPending) {
+          _logStreamController.add(
+              liquid_sdk.LogEntry(line: "Pending Payment Refund. ${event.details.swapId}", level: "INFO"));
+          _paymentResultStream.add(event.details);
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentSucceeded) {
+          _logStreamController
+              .add(liquid_sdk.LogEntry(line: "Payment Succeeded. ${event.details.swapId}", level: "INFO"));
+          _paymentResultStream.add(event.details);
+          await _fetchWalletData(sdk);
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentWaitingConfirmation) {
+          _logStreamController.add(liquid_sdk.LogEntry(
+              line: "Payment Waiting Confirmation. ${event.details.swapId}", level: "INFO"));
+          _paymentResultStream.add(event.details);
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_Synced) {
+          _logStreamController.add(const liquid_sdk.LogEntry(line: "Received Synced event.", level: "INFO"));
+          await _fetchWalletData(sdk);
+        }
+      },
+    );
+  }
+
+  final _logStreamController = StreamController<liquid_sdk.LogEntry>.broadcast();
+
+  Stream<liquid_sdk.LogEntry> get logStream => _logStreamController.stream;
+
+  /// Subscribes to SDK's logs stream
+  void _subscribeToLogStream() {
+    _breezLogSubscription = _breezLogStream?.listen((logEntry) {
+      _logStreamController.add(logEntry);
+    }, onError: (e) {
+      _logStreamController.addError(e);
+    });
+  }
+
+  /// Unsubscribes from SDK's event & log streams.
+  void _unsubscribeFromSdkStreams() {
+    _breezEventsSubscription?.cancel();
+    _breezLogSubscription?.cancel();
+  }
+}
+
+// TODO: Liquid - Return this exception from the SDK directly
+class PaymentException {
+  final liquid_sdk.Payment details;
+
+  const PaymentException(this.details);
+}

--- a/lib/bloc/account/payment_result.dart
+++ b/lib/bloc/account/payment_result.dart
@@ -1,5 +1,5 @@
-import 'package:breez_sdk/sdk.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/utils/exceptions.dart';
 import 'package:flutter/cupertino.dart';
 

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -1,11 +1,12 @@
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/bloc/account/breez_liquid_sdk.dart';
 import 'package:l_breez/bloc/backup/backup_state.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:logging/logging.dart';
 
 class BackupBloc extends Cubit<BackupState?> {
   final _log = Logger("BackupBloc");
-  final BindingLiquidSdk? _liquidSDK;
+  final BreezLiquidSDK _liquidSDK;
 
   BackupBloc(this._liquidSDK) : super(null);
 
@@ -21,7 +22,7 @@ class BackupBloc extends Cubit<BackupState?> {
   Future<void> backup() async {
     try {
       emit(BackupState(status: BackupStatus.INPROGRESS));
-      _liquidSDK?.backup(req: const BackupRequest());
+      _liquidSDK.wallet?.backup(req: const BackupRequest());
       emit(BackupState(status: BackupStatus.SUCCESS));
     } catch (e) {
       _log.info("Failed to backup");

--- a/lib/bloc/currency/currency_bloc.dart
+++ b/lib/bloc/currency/currency_bloc.dart
@@ -2,8 +2,9 @@ import 'dart:async';
 
 import 'package:breez_sdk/breez_sdk.dart';
 import 'package:breez_sdk/sdk.dart';
-import 'package:l_breez/bloc/currency/currency_state.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:l_breez/bloc/currency/currency_state.dart';
+import 'package:l_breez/services/injector.dart';
 
 class CurrencyBloc extends Cubit<CurrencyState> with HydratedMixin {
   final BreezSDK _breezSDK;
@@ -16,8 +17,9 @@ class CurrencyBloc extends Cubit<CurrencyState> with HydratedMixin {
   void _initializeCurrencyBloc() {
     late final StreamSubscription streamSubscription;
     // TODO: Liquid - Listen to Liquid SDK's invoice paid stream
-    streamSubscription = _breezSDK.nodeStateStream.where((nodeState) => nodeState != null).listen(
-      (nodeState) {
+    final breezLiquidSdk = ServiceInjector().liquidSDK;
+    streamSubscription = breezLiquidSdk.walletInfoStream.listen(
+      (walletInfo) {
         listFiatCurrencies();
         fetchExchangeRates();
         streamSubscription.cancel();

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -74,6 +74,7 @@ extension ConfigCopyWith on liquid_sdk.Config {
     String? workingDir,
     liquid_sdk.Network? network,
     BigInt? paymentTimeoutSec,
+    double? zeroConfMinFeeRate,
   }) {
     return liquid_sdk.Config(
       boltzUrl: boltzUrl ?? this.boltzUrl,
@@ -81,6 +82,7 @@ extension ConfigCopyWith on liquid_sdk.Config {
       workingDir: workingDir ?? this.workingDir,
       network: network ?? this.network,
       paymentTimeoutSec: paymentTimeoutSec ?? this.paymentTimeoutSec,
+      zeroConfMinFeeRate: zeroConfMinFeeRate ?? this.zeroConfMinFeeRate,
     );
   }
 }

--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -3,9 +3,8 @@ library breez.logger;
 import 'dart:io';
 
 import 'package:archive/archive_io.dart';
-import 'package:breez_sdk/breez_sdk.dart';
-import 'package:breez_sdk/generated/models.dart' as sdk_models;
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
+import 'package:l_breez/bloc/account/breez_liquid_sdk.dart';
 import 'package:l_breez/config.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
@@ -14,8 +13,6 @@ import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
 
 final _log = Logger("Logger");
-final _sdkLog = Logger("BreezSdk");
-// ignore: unused_element
 final _liquidSdkLog = Logger("BreezLiquidSdk");
 
 void shareLog() async {
@@ -83,17 +80,11 @@ class BreezLogger {
     });
   }
 
-  /// Log entries according to their severity
-  void registerBreezSdkLog(BreezSDK breezSDK) {
-    breezSDK.logStream.listen((e) => _logSdkEntries(e, _sdkLog));
+  void registerBreezLiquidSdkLogs(BreezLiquidSDK breezLiquidSDK) {
+    breezLiquidSDK.logStream.listen((e) => _logLiquidSdkEntries(e, _liquidSdkLog));
   }
 
-  // TODO: Liquid - Add Logger (log listener) similar to the breez sdk - https://github.com/breez/breez-liquid-sdk/issues/236
-  void registerBreezLiquidSdkLogs(liquid_sdk.BindingLiquidSdk liquidSDK) {
-    //liquidSDK.logStream.listen((e) => _logSdkEntries(e,_liquidSdkLog));
-  }
-
-  void _logSdkEntries(sdk_models.LogEntry log, Logger logger) {
+  void _logLiquidSdkEntries(liquid_sdk.LogEntry log, Logger logger) {
     switch (log.level) {
       case "ERROR":
         logger.severe(log.line);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,8 @@ void main() async {
     SystemChrome.setPreferredOrientations(
       [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown],
     );
+    // Initialize library
+    await liquid_sdk.initialize();
     //initializeDateFormatting(Platform.localeName, null);
     BreezDateUtils.setupLocales();
     //await Firebase.initializeApp();
@@ -42,9 +44,13 @@ void main() async {
     final breezSDK = injector.breezSDK;
     if (!await breezSDK.isInitialized()) {
       breezSDK.initialize();
-      breezLogger.registerBreezSdkLog(breezSDK);
     }
-    await liquid_sdk.initialize();
+
+    // Initialize Log Stream
+    if (injector.liquidSDK.wallet == null) {
+      injector.liquidSDK.initializeLogStream();
+      breezLogger.registerBreezLiquidSdkLogs(injector.liquidSDK);
+    }
 
     final appDir = await getApplicationDocumentsDirectory();
 
@@ -63,7 +69,7 @@ void main() async {
         providers: [
           BlocProvider<AccountBloc>(
             create: (BuildContext context) => AccountBloc(
-              breezSDK,
+              injector.liquidSDK,
               CredentialsManager(keyChain: injector.keychain),
             ),
           ),
@@ -82,7 +88,9 @@ void main() async {
           BlocProvider<SecurityBloc>(
             create: (BuildContext context) => SecurityBloc(),
           ),
-          BlocProvider<BackupBloc>(create: (BuildContext context) => BackupBloc(injector.liquidSDK)),
+          BlocProvider<BackupBloc>(
+            create: (BuildContext context) => BackupBloc(injector.liquidSDK),
+          ),
         ],
         child: UserApp(),
       ),

--- a/lib/models/payment_minutiae.dart
+++ b/lib/models/payment_minutiae.dart
@@ -30,7 +30,7 @@ class PaymentMinutiae {
   factory PaymentMinutiae.fromPayment(Payment payment, BreezTranslations texts) {
     final factory = _PaymentMinutiaeFactory(payment, texts);
     return PaymentMinutiae(
-      id: payment.txId,
+      id: payment.txId ?? "",
       title: factory._title(),
       preimage: payment.preimage ?? "",
       swapId: payment.swapId ?? "",

--- a/lib/models/payment_minutiae.dart
+++ b/lib/models/payment_minutiae.dart
@@ -36,7 +36,7 @@ class PaymentMinutiae {
       swapId: payment.swapId ?? "",
       paymentType: payment.paymentType,
       paymentTime: factory._paymentTime(),
-      feeSat: payment.feesSat?.toInt() ?? 0,
+      feeSat: payment.feesSat.toInt(),
       amountSat: payment.amountSat.toInt(),
       status: payment.status,
     );

--- a/lib/services/injector.dart
+++ b/lib/services/injector.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:breez_liquid/breez_liquid.dart';
 import 'package:breez_sdk/breez_sdk.dart';
+import 'package:l_breez/bloc/account/breez_liquid_sdk.dart';
 import 'package:l_breez/logger.dart';
 import 'package:l_breez/services/deep_links.dart';
 import 'package:l_breez/services/device.dart';
@@ -20,7 +20,7 @@ class ServiceInjector {
 
   // breez sdk
   BreezSDK? _breezSDK;
-  BindingLiquidSdk? _liquidSDK;
+  BreezLiquidSDK? _liquidSDK;
   LightningLinksService? _lightningLinksService;
 
   Device? _device;
@@ -53,7 +53,5 @@ class ServiceInjector {
 
   BreezLogger get breezLogger => _breezLogger ??= BreezLogger();
 
-  void setLiquidSdk(BindingLiquidSdk liquidSDK) => _liquidSDK = liquidSDK;
-
-  BindingLiquidSdk? get liquidSDK => _liquidSDK;
+  BreezLiquidSDK get liquidSDK => _liquidSDK ??= BreezLiquidSDK();
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: e4be6711f96d3d4eebe79728897d645b7a5585bbfdd6d534878d202c171266d7
+      sha256: "37a42d06068e2fe3deddb2da079a8c4d105f241225ba27b7122b37e9865fd8f7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.34"
+    version: "1.3.35"
   analyzer:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: archive
-      sha256: "6bd38d335f0954f5fad9c79e614604fbf03a0e5b975923dd001b6ea965ef5b4b"
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.0"
+    version: "3.6.1"
   args:
     dependency: transitive
     description:
@@ -164,18 +164,18 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1414d6d733a85d8ad2f1dfcb3ea7945759e35a123cb99ccfac75d0758f75edfa"
+      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.4.11"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "4ae8ffe5ac758da294ecf1802f2aff01558d8b1b00616aa7538ea9a8a5d50799"
+      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "7.3.1"
   built_collection:
     dependency: transitive
     description:
@@ -365,10 +365,10 @@ packages:
     dependency: "direct main"
     description:
       name: extended_image
-      sha256: d7f091d068fcac7246c4b22a84b8dac59a62e04d29a5c172710c696e67a22f94
+      sha256: "9786aab821aac117763d6e4419cd49f5031fbaacfe3fd212c5b313d0334c37a9"
       url: "https://pub.dev"
     source: hosted
-    version: "8.2.0"
+    version: "8.2.1"
   extended_image_library:
     dependency: transitive
     description:
@@ -445,66 +445,66 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "4b5100e2dbc3fe72c2d4241a046d3f01457fe11293283a324f5c52575e3406f8"
+      sha256: "26de145bb9688a90962faec6f838247377b0b0d32cc0abecd9a4e43525fc856c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.1"
+    version: "2.32.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: c437ae5d17e6b5cc7981cf6fd458a5db4d12979905f9aafd1fea930428a9fe63
+      sha256: "1003a5a03a61fc9a22ef49f37cbcb9e46c86313a7b2e7029b9390cf8c6fc32cb"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "43d9e951ac52b87ae9cc38ecdcca1e8fa7b52a1dd26a96085ba41ce5108db8e9"
+      sha256: "6643fe3dbd021e6ccfb751f7882b39df355708afbdeb4130fc50f9305a9d1a3d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.17.0"
+    version: "2.17.2"
   firebase_dynamic_links:
     dependency: "direct main"
     description:
       name: firebase_dynamic_links
-      sha256: "6bcd62455bb814a1183fc4e1577ee92b65d410c80419e58acd2982ddbf47831f"
+      sha256: "47b8c8a8546d8a7f9000edb90848549f20b137d814ee7e0407b3d43b8445e282"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.6"
+    version: "5.5.7"
   firebase_dynamic_links_platform_interface:
     dependency: transitive
     description:
       name: firebase_dynamic_links_platform_interface
-      sha256: c507b7363650201e85e52c9c1a34b143159691a49130bf2a2a2f182b3b0be0f0
+      sha256: "72e7810635f908ce060c5803c7acb29116c5b6befc73e90446c52722bc9506a2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.6+34"
+    version: "0.2.6+35"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "62c27bd7c9c724b5ee5fd52e06224b8861d6e692f08b3d7bc3ada28552f27d41"
+      sha256: a1662cc95d9750a324ad9df349b873360af6f11414902021f130c68ec02267c4
       url: "https://pub.dev"
     source: hosted
-    version: "14.9.3"
+    version: "14.9.4"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: f73e9fe4bc25307520b714cec39a2e1a625c64511d497964f3e06c5d60146948
+      sha256: "87c4a922cb6f811cfb7a889bdbb3622702443c52a0271636cbc90d813ceac147"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.36"
+    version: "4.5.37"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "5ed108929f988d55c497f1456ad5e407501a746869306f058b6d2b2e704790f3"
+      sha256: "0d34dca01a7b103ed7f20138bffbb28eb0e61a677bf9e78a028a932e2c7322d5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.6"
+    version: "3.8.7"
   fixnum:
     dependency: transitive
     description:
@@ -522,10 +522,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: f0ecf6e6eb955193ca60af2d5ca39565a86b8a142452c5b24d96fb477428f4d2
+      sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.5"
+    version: "8.1.6"
   flutter_breez_liquid:
     dependency: "direct main"
     description:
@@ -668,18 +668,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "8cf40eebf5dec866a6d1956ad7b4f7016e6c0cc69847ab946833b7d43743809f"
+      sha256: c6b0b4c05c458e1c01ad9bcc14041dd7b1f6783d487be4386f793f47a8a4d03e
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.19"
+    version: "2.0.20"
   flutter_rust_bridge:
     dependency: "direct main"
     description:
       name: flutter_rust_bridge
-      sha256: efb018e387c5e844095e35e9d6c6bd1610c49f25de109f4988b7c45aeca60a9a
+      sha256: "867ae0e50cf856ab9fe8d26f88319aa5ec47b3e641e055280bdc626d6f5cd0f2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0-dev.36"
+    version: "2.0.0-dev.38"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -892,18 +892,18 @@ packages:
     dependency: "direct main"
     description:
       name: image_picker
-      sha256: "33974eca2e87e8b4e3727f1b94fa3abcb25afe80b6bc2c4d449a0e150aedf720"
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   image_picker_android:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "0f57fee1e8bfadf8cc41818bbcd7f72e53bb768a54d9496355d5e8a5681a19f1"
+      sha256: "4161e1f843d8480d2e9025ee22411778c3c9eb7e40076dcf2da23d8242b7b51c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+1"
+    version: "0.8.12+3"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -916,10 +916,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: "4824d8c7f6f89121ef0122ff79bb00b009607faecc8545b86bca9ab5ce1e95bf"
+      sha256: "6703696ad49f5c3c8356d576d7ace84d1faf459afb07accbb0fae780753ff447"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.11+2"
+    version: "0.8.12"
   image_picker_linux:
     dependency: transitive
     description:
@@ -1041,10 +1041,10 @@ packages:
     dependency: "direct main"
     description:
       name: local_auth_android
-      sha256: e0e5b1ea247c5a0951c13a7ee13dc1beae69750e6a2e1910d1ed6a3cd4d56943
+      sha256: "48dfb2d954da8ef6a77adfc93a29998f7729e9308eaa817e91dea4500317b2c8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.38"
+    version: "1.0.39"
   local_auth_darwin:
     dependency: "direct main"
     description:
@@ -1201,10 +1201,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: a248d8146ee5983446bf03ed5ea8f6533129a12b11f12057ad1b4a67a2b3b41d
+      sha256: "9c96da072b421e98183f9ea7464898428e764bc0ce5567f27ec8693442e72514"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.4"
+    version: "2.2.5"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1305,10 +1305,10 @@ packages:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.3.0"
   qr:
     dependency: transitive
     description:
@@ -1377,10 +1377,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "1ee8bf911094a1b592de7ab29add6f826a7331fb854273d55918693d5364a1f2"
+      sha256: "93d0ec9dd902d85f326068e6a899487d1f65ffcd5798721a95330b26c8131577"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1534,10 +1534,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3_flutter_libs
-      sha256: "1e62698dc1ab396152ccaf3b3990d826244e9f3c8c39b51805f209adcd6dbea3"
+      sha256: "9f89a7e7dc36eac2035808427eba1c3fbd79e59c3a22093d8dace6d36b1fe89e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.22"
+    version: "0.5.23"
   stack_trace:
     dependency: transitive
     description:
@@ -1598,10 +1598,10 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: d11b55850c68c1f6c0cf00eabded4e66c4043feaf6c0d7ce4a36785137df6331
+      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.5"
+    version: "1.25.7"
   test_api:
     dependency: "direct overridden"
     description:
@@ -1614,10 +1614,10 @@ packages:
     dependency: transitive
     description:
       name: test_core
-      sha256: "4d070a6bc36c1c4e89f20d353bfd71dc30cdf2bd0e14349090af360a029ab292"
+      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.4"
   theme_provider:
     dependency: "direct main"
     description:
@@ -1678,18 +1678,18 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "6ce1e04375be4eed30548f10a315826fd933c1e493206eab82eed01f438c8d2e"
+      sha256: "21b704ce5fa560ea9f3b525b43601c678728ba46725bab9b01187b4831377ed3"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.6"
+    version: "6.3.0"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "17cd5e205ea615e2c6ea7a77323a11712dffa0720a8a90540db57a01347f9ad9"
+      sha256: ceb2625f0c24ade6ef6778d1de0b2e44f2db71fded235eb52295247feba8c5cf
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.2"
+    version: "6.3.3"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1806,10 +1806,10 @@ packages:
     dependency: transitive
     description:
       name: web_socket
-      sha256: "217f49b5213796cb508d6a942a5dc604ce1cb6a0a6b3d8cb3f0c314f0ecea712"
+      sha256: "24301d8c293ce6fe327ffe6f59d8fd8834735f0ec36e4fd383ec7ff8a64aa078"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1884,4 +1884,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
     path: ../breez-liquid-sdk/packages/dart
   flutter_breez_liquid:
     path: ../breez-liquid-sdk/packages/flutter
-  flutter_rust_bridge: ">= 2.0.0-dev.0 <=2.0.0-dev.36"
+  flutter_rust_bridge: ">=2.0.0-dev.38"
   breez_translations:
     git:
       url: https://github.com/breez/Breez-Translations


### PR DESCRIPTION
This PR addresses
-  #14 

l-breez now relies on event & log streams of Liquid SDK plugin for logging purposes & event management.

A helper class `BreezLiquidSDK` is introduced that manages connections & stream handling.

#### Other changes:
- Renamed node state to wallet info
- Applied breaking changes for
  - https://github.com/breez/breez-liquid-sdk/pull/306
    - `getInfo` API no longer has a request param
  - https://github.com/breez/breez-liquid-sdk/pull/301
    - `Payment.txID` is now an optional field
  - https://github.com/breez/breez-liquid-sdk/pull/292
    - A new optional field, `zeroConfMinFeeRate` is added to `Config`
  - https://github.com/breez/breez-liquid-sdk/pull/265
    - `Payment.feesSat` is no longer an optional field