### PR TITLE
Improvements to Send/Receive Payment UX

### DIFF
--- a/lib/bloc/input/input_bloc.dart
+++ b/lib/bloc/input/input_bloc.dart
@@ -39,10 +39,11 @@ class InputBloc extends Cubit<InputState> {
 
   Future trackPayment(String? invoiceId) async {
     _log.info("Tracking incoming payment: $invoiceId");
-    await ServiceInjector().liquidSDK.paymentsStream.firstWhere(
-      (paymentList) {
-        if (paymentList.any((e) => e.swapId == invoiceId)) {
-          if (invoiceId != null && invoiceId.isNotEmpty) {
+    await ServiceInjector().liquidSDK.paymentResultStream.firstWhere(
+      (payment) {
+        if (invoiceId != null && invoiceId.isNotEmpty) {
+          if (payment.swapId == invoiceId &&
+              (payment.status == PaymentState.pending || payment.status == PaymentState.complete)) {
             _log.info("Payment Received! Id: $invoiceId");
             return true;
           }

--- a/lib/widgets/payment_dialogs/payment_request_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_dialog.dart
@@ -79,8 +79,12 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
         firstPaymentItemKey: widget.firstPaymentItemKey,
         minHeight: minHeight,
         paymentFunc: () async {
-          final resp = await accountBloc.prepareSendPayment(widget.invoice.bolt11);
-          return accountBloc.sendPayment(resp);
+          try {
+            final prepareSendResponse = await accountBloc.prepareSendPayment(widget.invoice.bolt11);
+            return await accountBloc.sendPayment(prepareSendResponse);
+          } catch (e) {
+            rethrow;
+          }
         },
         onStateChange: (state) => _onStateChange(state),
       );

--- a/lib/widgets/payment_dialogs/processing_payment_dialog.dart
+++ b/lib/widgets/payment_dialogs/processing_payment_dialog.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/widgets/flushbar.dart';
 import 'package:l_breez/widgets/payment_dialogs/payment_request_dialog.dart';
@@ -105,7 +106,7 @@ class ProcessingPaymentDialogState extends State<ProcessingPaymentDialog>
       if (widget.isLnurlPayment) {
         navigator.pop(err);
       }
-      if (err is FrbException) {
+      if (err is FrbException || err is PaymentError_PaymentTimeout) {
         if (_currentRoute != null && _currentRoute!.isActive) {
           navigator.removeRoute(_currentRoute!);
         }


### PR DESCRIPTION
This PR adds improvements to Send/Receive Payment UX per feedback.

- Payment in progress dialog now closes once `sendPayment` API call completes 
  - Timeout errors are now displayed on payment in progress dialog
-  Invoice dialog closes once incoming payment is in progress