### PR TITLE
Remove Breez SDK dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: 'main'
-      breez_sdk_ref:
-        description: 'Breez SDK commit/tag/branch reference'
-        required: false
-        type: string
-        default: 'flutter_rust_bridge_v2'
   workflow_call:
     inputs:
       liquid_sdk_ref:
@@ -39,15 +34,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           path: 'lbreez'
-
-      # TODO: Liquid - Revert once breez-sdk dependency is removed
-      - name: 🏗️ Setup breez-sdk repository
-        uses: actions/checkout@v4
-        with:
-          repository: 'breez/breez-sdk'
-          ssh-key: ${{secrets.REPO_SSH_KEY}}
-          path: 'breez-sdk'
-          ref: ${{ inputs.breez_sdk_ref || 'flutter_rust_bridge_v2' }}
 
       - name: 🏗️ Setup breez-liquid-sdk repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -7,11 +7,6 @@ on:
         required: false
         type: string
         default: 'main'
-      breez_sdk_ref:
-        description: 'Breez SDK commit/tag/branch reference'
-        required: false
-        type: string
-        default: 'flutter_rust_bridge_v2'
 
 jobs:
   build-android:
@@ -72,15 +67,6 @@ jobs:
         env:
           GOOGLE_SERVICES: ${{secrets.GOOGLE_SERVICES}}
         run: echo "$GOOGLE_SERVICES" > android/app/google-services.json
-
-      # TODO: Liquid - Revert once breez-sdk dependency is removed
-      - name: 🏗️ Setup breez-sdk repository
-        uses: actions/checkout@v4
-        with:
-          repository: 'breez/breez-sdk'
-          ssh-key: ${{secrets.REPO_SSH_KEY}}
-          path: 'breez-sdk'
-          ref: ${{ inputs.breez_sdk_ref }}
 
       - name: 🏗️ Setup breez-liquid-sdk repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -87,6 +87,7 @@ jobs:
         run: |
           just clean
           just init
+          just init-sdk
 
       - name: Install flutter_rust_bridge_codegen dependencies
         working-directory: breez-liquid-sdk/lib/bindings/langs/flutter/

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -7,11 +7,6 @@ on:
         required: false
         type: string
         default: 'main'
-      breez_sdk_ref:
-        description: 'Breez SDK commit/tag/branch reference'
-        required: false
-        type: string
-        default: 'flutter_rust_bridge_v2'
 
 jobs:
   build-ios:
@@ -78,15 +73,6 @@ jobs:
       - name: 🏗️ Copy Firebase configuration file
         working-directory: lbreez
         run: echo "$GOOGLE_SERVICES_IOS" > ios/Runner/GoogleService-Info.plist
-
-      # TODO: Liquid - Revert once breez-sdk dependency is removed
-      - name: 🏗️ Setup breez-sdk repository
-        uses: actions/checkout@v4
-        with:
-          repository: 'breez/breez-sdk'
-          ssh-key: ${{secrets.REPO_SSH_KEY}}
-          path: 'breez-sdk'
-          ref: ${{ inputs.breez_sdk_ref }}
 
       - name: 🏗️ Setup breez-liquid-sdk repository
         uses: actions/checkout@v4

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -33,11 +33,11 @@ PODS:
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreInternal (10.27.0):
+  - FirebaseCoreInternal (10.28.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - FirebaseDynamicLinks (10.25.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseInstallations (10.27.0):
+  - FirebaseInstallations (10.28.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -156,18 +156,21 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - sqlite3 (3.46.0):
-    - sqlite3/common (= 3.46.0)
-  - sqlite3/common (3.46.0)
-  - sqlite3/fts5 (3.46.0):
+  - "sqlite3 (3.46.0+1)":
+    - "sqlite3/common (= 3.46.0+1)"
+  - "sqlite3/common (3.46.0+1)"
+  - "sqlite3/dbstatvtab (3.46.0+1)":
     - sqlite3/common
-  - sqlite3/perf-threadsafe (3.46.0):
+  - "sqlite3/fts5 (3.46.0+1)":
     - sqlite3/common
-  - sqlite3/rtree (3.46.0):
+  - "sqlite3/perf-threadsafe (3.46.0+1)":
+    - sqlite3/common
+  - "sqlite3/rtree (3.46.0+1)":
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - Flutter
-    - sqlite3 (~> 3.46.0)
+    - "sqlite3 (~> 3.46.0+1)"
+    - sqlite3/dbstatvtab
     - sqlite3/fts5
     - sqlite3/perf-threadsafe
     - sqlite3/rtree
@@ -297,9 +300,9 @@ SPEC CHECKSUMS:
   firebase_dynamic_links: 525e9c1b702d2ed2d9b0dbd342eee1e15a75e62d
   firebase_messaging: 06391e8f35dc65a00c56580266285263d2861f10
   FirebaseCore: 7ec4d0484817f12c3373955bc87762d96842d483
-  FirebaseCoreInternal: 4b297a2d56063dbea2c1d0d04222d44a8d058862
+  FirebaseCoreInternal: 58d07f1362fddeb0feb6a857d1d1d1c5e558e698
   FirebaseDynamicLinks: 12c9f5b643943e0565ed28080373f89cbcb914a3
-  FirebaseInstallations: 766dabca09fd94aef922538aaf144cc4a6fb6869
+  FirebaseInstallations: 60c1d3bc1beef809fd1ad1189a8057a040c59f2e
   FirebaseMessaging: 88950ba9485052891ebe26f6c43a52bb62248952
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_breez_liquid: 90494dd8df26d6258f0d2a90663204ee6257ede2
@@ -330,8 +333,8 @@ SPEC CHECKSUMS:
   share_plus: 8875f4f2500512ea181eef553c3e27dba5135aad
   shared_preference_app_group: 46aee3873e1da581d4904bece9876596d7f66725
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqlite3: 154b084339ede06960a5b3c8160066adc9176b7d
-  sqlite3_flutter_libs: 0d611efdf6d1c9297d5ab03dab21b75aeebdae31
+  sqlite3: 292c3e1bfe89f64e51ea7fc7dab9182a017c8630
+  sqlite3_flutter_libs: c00457ebd31e59fa6bb830380ddba24d44fbcd3b
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,8 +1,6 @@
 PODS:
   - app_group_directory (1.0.0):
     - Flutter
-  - breez_sdk (0.4.0):
-    - Flutter
   - clipboard_watcher (0.0.1):
     - Flutter
   - connectivity_plus (0.0.1):
@@ -182,7 +180,6 @@ PODS:
 
 DEPENDENCIES:
   - app_group_directory (from `.symlinks/plugins/app_group_directory/ios`)
-  - breez_sdk (from `.symlinks/plugins/breez_sdk/ios`)
   - clipboard_watcher (from `.symlinks/plugins/clipboard_watcher/ios`)
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/darwin`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
@@ -236,8 +233,6 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   app_group_directory:
     :path: ".symlinks/plugins/app_group_directory/ios"
-  breez_sdk:
-    :path: ".symlinks/plugins/breez_sdk/ios"
   clipboard_watcher:
     :path: ".symlinks/plugins/clipboard_watcher/ios"
   connectivity_plus:
@@ -291,7 +286,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   app_group_directory: 7bf9f8f9819ead554de29da7c25fb7a680d6a9a0
-  breez_sdk: 503ffaabe90dafa43852d1c2927f7e246194d404
   clipboard_watcher: 86fb70421aca6f4944e0591a8292605da7784666
   connectivity_plus: ddd7f30999e1faaef5967c23d5b6d503d10434db
   device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d

--- a/lib/bloc/currency/currency_state.dart
+++ b/lib/bloc/currency/currency_state.dart
@@ -1,4 +1,4 @@
-import 'package:breez_sdk/sdk.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/models/currency.dart';
 import 'package:l_breez/utils/fiat_conversion.dart';
 

--- a/lib/bloc/input/input_bloc.dart
+++ b/lib/bloc/input/input_bloc.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:breez_sdk/sdk.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
 import 'package:l_breez/bloc/input/input_data.dart';

--- a/lib/bloc/input/input_printer.dart
+++ b/lib/bloc/input/input_printer.dart
@@ -1,4 +1,4 @@
-import 'package:breez_sdk/sdk.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 
 String inputTypeToString(InputType inputType) {
   if (inputType is InputType_BitcoinAddress) {

--- a/lib/bloc/input/input_state.dart
+++ b/lib/bloc/input/input_state.dart
@@ -1,4 +1,4 @@
-import 'package:breez_sdk/sdk.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/input/input_printer.dart';
 import 'package:l_breez/bloc/input/input_source.dart';
 import 'package:l_breez/models/invoice.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,11 +40,6 @@ void main() async {
     //await Firebase.initializeApp();
     final injector = ServiceInjector();
     var breezLogger = injector.breezLogger;
-    // TODO: Liquid - Remove all BreezSDK logic - Requires FiatCurrency & InputParser to be extracted to a shared library among SDK's
-    final breezSDK = injector.breezSDK;
-    if (!await breezSDK.isInitialized()) {
-      breezSDK.initialize();
-    }
 
     // Initialize Log Stream
     if (injector.liquidSDK.wallet == null) {
@@ -83,7 +78,7 @@ void main() async {
             create: (BuildContext context) => UserProfileBloc(),
           ),
           BlocProvider<CurrencyBloc>(
-            create: (BuildContext context) => CurrencyBloc(breezSDK),
+            create: (BuildContext context) => CurrencyBloc(injector.liquidSDK),
           ),
           BlocProvider<SecurityBloc>(
             create: (BuildContext context) => SecurityBloc(),

--- a/lib/routes/fiat_currencies/fiat_currency_settings.dart
+++ b/lib/routes/fiat_currencies/fiat_currency_settings.dart
@@ -1,6 +1,6 @@
-import 'package:breez_sdk/sdk.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/currency/currency_bloc.dart';
 import 'package:l_breez/bloc/currency/currency_state.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;

--- a/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
@@ -208,13 +208,15 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
     final texts = context.texts();
     try {
       _setValidatorErrorMessage("");
-      // TODO: Liquid - Previously parseInput, parseInvoice only parses LNInvoice's.
-      final inputType = context.read<InputBloc>().parseInvoice(input: input);
+      final inputType = context.read<InputBloc>().parseInput(input: input);
       _log.info("Parsed input type: '${inputType.runtimeType.toString()}");
       // Can't compare against a list of InputType as runtime type comparison is a bit tricky with binding generated enums
-      // TODO: Liquid - Add other supported InputType's once parse_invoice has evolved into parse_input.
-      // ignore: unnecessary_type_check
-      if (inputType is! LNInvoice) {
+      if (!(inputType is InputType_Bolt11 ||
+          inputType is InputType_LnUrlPay ||
+          inputType is InputType_LnUrlWithdraw ||
+          inputType is InputType_LnUrlAuth ||
+          inputType is InputType_LnUrlError ||
+          inputType is InputType_NodeId)) {
         _setValidatorErrorMessage(texts.payment_info_dialog_error_unsupported_input);
       }
     } catch (e) {

--- a/lib/services/injector.dart
+++ b/lib/services/injector.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:breez_sdk/breez_sdk.dart';
 import 'package:l_breez/bloc/account/breez_liquid_sdk.dart';
 import 'package:l_breez/logger.dart';
 import 'package:l_breez/services/deep_links.dart';
@@ -19,7 +18,6 @@ class ServiceInjector {
   DeepLinksService? _deepLinksService;
 
   // breez sdk
-  BreezSDK? _breezSDK;
   BreezLiquidSDK? _liquidSDK;
   LightningLinksService? _lightningLinksService;
 
@@ -36,8 +34,6 @@ class ServiceInjector {
   static void configure(ServiceInjector injector) => _injector = injector;
 
   Notifications get notifications => _notifications ??= FirebaseNotifications();
-
-  BreezSDK get breezSDK => _breezSDK ??= BreezSDK();
 
   Device get device => _device ??= Device();
 

--- a/lib/utils/fiat_conversion.dart
+++ b/lib/utils/fiat_conversion.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:breez_sdk/sdk.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/utils/currency_formatter.dart';
 
 class FiatConversion {

--- a/lib/widgets/amount_form_field/amount_form_field.dart
+++ b/lib/widgets/amount_form_field/amount_form_field.dart
@@ -1,10 +1,13 @@
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:l_breez/bloc/currency/currency_bloc.dart';
 import 'package:l_breez/models/currency.dart';
+import 'package:l_breez/theme/theme_provider.dart';
 import 'package:l_breez/utils/fiat_conversion.dart';
-
-import 'sat_amount_form_field_formatter.dart';
+import 'package:l_breez/widgets/amount_form_field/currency_converter_dialog.dart';
+import 'package:l_breez/widgets/amount_form_field/sat_amount_form_field_formatter.dart';
 
 class AmountFormField extends TextFormField {
   final FiatConversion? fiatConversion;
@@ -42,8 +45,6 @@ class AmountFormField extends TextFormField {
             labelText: texts.amount_form_denomination(
               bitcoinCurrency.displayName,
             ),
-            // TODO: Liquid - Hide CurrencyConverterDialog button until Fiat Currencies are supported on Liquid SDK
-            /*
             suffixIcon: (readOnly ?? false)
                 ? null
                 : IconButton(
@@ -51,7 +52,7 @@ class AmountFormField extends TextFormField {
                       (fiatConversion?.currencyData != null)
                           ? fiatConversion!.logoPath
                           : "src/icon/btc_convert.png",
-                      color: iconColor ?? theme.BreezColors.white[500],
+                      color: iconColor ?? BreezColors.white[500],
                     ),
                     padding: const EdgeInsets.only(top: 21.0),
                     alignment: Alignment.bottomRight,
@@ -70,7 +71,6 @@ class AmountFormField extends TextFormField {
                       ),
                     ),
                   ),
-             */
           ),
           inputFormatters: bitcoinCurrency != BitcoinCurrency.SAT
               ? [

--- a/lib/widgets/amount_form_field/currency_converter_dialog.dart
+++ b/lib/widgets/amount_form_field/currency_converter_dialog.dart
@@ -1,6 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:breez_sdk/sdk.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/currency/currency_bloc.dart';
 import 'package:l_breez/bloc/currency/currency_state.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -104,13 +104,6 @@ packages:
       relative: true
     source: path
     version: "0.1.0"
-  breez_sdk:
-    dependency: "direct main"
-    description:
-      path: "../breez-sdk/libs/sdk-flutter"
-      relative: true
-    source: path
-    version: "0.4.0"
   breez_translations:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -676,10 +676,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_rust_bridge
-      sha256: "867ae0e50cf856ab9fe8d26f88319aa5ec47b3e641e055280bdc626d6f5cd0f2"
+      sha256: f703c4b50e253e53efc604d50281bbaefe82d615856f8ae1e7625518ae252e98
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0-dev.38"
+    version: "2.0.0"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -1041,10 +1041,10 @@ packages:
     dependency: "direct main"
     description:
       name: local_auth_android
-      sha256: "48dfb2d954da8ef6a77adfc93a29998f7729e9308eaa817e91dea4500317b2c8"
+      sha256: b77dc490fef9214e785c326bf11fa733feaa47675d0433f05f48b5caa486c8f7
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.39"
+    version: "1.0.40"
   local_auth_darwin:
     dependency: "direct main"
     description:
@@ -1201,10 +1201,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "9c96da072b421e98183f9ea7464898428e764bc0ce5567f27ec8693442e72514"
+      sha256: bca87b0165ffd7cdb9cad8edd22d18d2201e886d9a9f19b4fb3452ea7df3a72a
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.5"
+    version: "2.2.6"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1337,10 +1337,10 @@ packages:
     dependency: "direct main"
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "0.27.7"
+    version: "0.28.0"
   share_plus:
     dependency: "direct main"
     description:
@@ -1526,18 +1526,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: b384f598b813b347c5a7e5ffad82cbaff1bec3d1561af267041e66f6f0899295
+      sha256: "6d17989c0b06a5870b2190d391925186f944cb943e5262d0d3f778fcfca3bc6e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.4"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
       name: sqlite3_flutter_libs
-      sha256: "9f89a7e7dc36eac2035808427eba1c3fbd79e59c3a22093d8dace6d36b1fe89e"
+      sha256: "62bbb4073edbcdf53f40c80775f33eea01d301b7b81417e5b3fb7395416258c1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.23"
+    version: "0.5.24"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,6 @@ dependencies:
   archive: ^3.6.0
   auto_size_text: ^3.0.0
   bip39: ^1.0.6
-  breez_sdk:
-    path: ../breez-sdk/libs/sdk-flutter
   breez_liquid:
     path: ../breez-liquid-sdk/packages/dart
   flutter_breez_liquid:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
-  flutter: ">=3.19.0"
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: ">=3.22.0"
 
 dependencies:
   flutter:
@@ -24,7 +24,7 @@ dependencies:
     path: ../breez-liquid-sdk/packages/dart
   flutter_breez_liquid:
     path: ../breez-liquid-sdk/packages/flutter
-  flutter_rust_bridge: ">=2.0.0-dev.38"
+  flutter_rust_bridge: ^2.0.0
   breez_translations:
     git:
       url: https://github.com/breez/Breez-Translations
@@ -108,9 +108,7 @@ dev_dependencies:
 dependency_overrides:
   test_api: <0.7.1 # test_api >=0.7.1 is incompatible with flutter_test from the flutter SDK
   intl: ^0.19.0 # intl is pinned to version 0.18.1 by flutter_localizations from the flutter SDK.
-  # Comment-out to work with breez-sdk from git repository
-  breez_sdk:
-    path: ../breez-sdk/libs/sdk-flutter
+  # Comment-out to work with liquid-sdk from git repository
   breez_liquid:
     path: ../breez-liquid-sdk/packages/dart
   flutter_breez_liquid:


### PR DESCRIPTION
[![Run CI](https://github.com/breez/l-breez/actions/workflows/CI.yml/badge.svg?branch=breez-sdk-removal)](https://github.com/breez/l-breez/actions/workflows/CI.yml)
Depends on:
- https://github.com/breez/breez-liquid-sdk/pull/331
---
This PR removes Breez SDK as shared modules are fully moved to `sdk-common` and is now accessible from Liquid SDK.

#### Changelist:
 - Update `CurrencyBloc` to use `FiatAPI`
   - Re-enable `CurrencyConverterDialog`
 - Integrate input parser
   - We recognize almost all input types at the moment but input handling will be enabled as part of another PR: #30
 - Remove Breez SDK setup steps from CI workflow
 - Update dependencies to latest