### PR TITLE
Rename `wallet` to `instance`

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -136,7 +136,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     var lastSync = DateTime.fromMillisecondsSinceEpoch(0);
     FGBGEvents.stream.listen((event) async {
       if (event == FGBGType.foreground && DateTime.now().difference(lastSync).inSeconds > nodeSyncInterval) {
-        _breezLiquidSdk.wallet?.sync();
+        _breezLiquidSdk.instance?.sync();
         lastSync = DateTime.now();
       }
     });
@@ -146,7 +146,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     _log.info("prepareSendPayment: $invoice");
     try {
       final req = liquid_sdk.PrepareSendRequest(invoice: invoice);
-      return await _breezLiquidSdk.wallet!.prepareSendPayment(req: req);
+      return await _breezLiquidSdk.instance!.prepareSendPayment(req: req);
     } catch (e) {
       _log.severe("prepareSendPayment error", e);
       return Future.error(e);
@@ -156,7 +156,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
   Future<liquid_sdk.SendPaymentResponse> sendPayment(liquid_sdk.PrepareSendResponse req) async {
     _log.info("sendPayment: $req");
     try {
-      return await _breezLiquidSdk.wallet!.sendPayment(req: req);
+      return await _breezLiquidSdk.instance!.sendPayment(req: req);
     } catch (e) {
       _log.severe("sendPayment error", e);
       return Future.error(e);
@@ -167,7 +167,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     _log.info("prepareReceivePayment: $payerAmountSat");
     try {
       final req = liquid_sdk.PrepareReceiveRequest(payerAmountSat: BigInt.from(payerAmountSat));
-      return _breezLiquidSdk.wallet!.prepareReceivePayment(req: req);
+      return _breezLiquidSdk.instance!.prepareReceivePayment(req: req);
     } catch (e) {
       _log.severe("prepareSendPayment error", e);
       return Future.error(e);
@@ -177,7 +177,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
   Future<liquid_sdk.ReceivePaymentResponse> receivePayment(liquid_sdk.PrepareReceiveResponse req) async {
     _log.info("receivePayment: ${req.payerAmountSat}, fees: ${req.feesSat}");
     try {
-      return _breezLiquidSdk.wallet!.receivePayment(req: req);
+      return _breezLiquidSdk.instance!.receivePayment(req: req);
     } catch (e) {
       _log.severe("prepareSendPayment error", e);
       return Future.error(e);

--- a/lib/bloc/account/account_state_assembler.dart
+++ b/lib/bloc/account/account_state_assembler.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/account/payment_filters.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
 

--- a/lib/bloc/account/breez_liquid_sdk.dart
+++ b/lib/bloc/account/breez_liquid_sdk.dart
@@ -4,16 +4,16 @@ import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
 import 'package:rxdart/rxdart.dart';
 
 class BreezLiquidSDK {
-  liquid_sdk.BindingLiquidSdk? wallet;
+  liquid_sdk.BindingLiquidSdk? instance;
 
   Future<liquid_sdk.BindingLiquidSdk> connect({
     required liquid_sdk.ConnectRequest req,
   }) async {
-    wallet = await liquid_sdk.connect(req: req);
-    _initializeEventsStream(wallet!);
-    _subscribeToSdkStreams(wallet!);
-    await _fetchWalletData(wallet!);
-    return wallet!;
+    instance = await liquid_sdk.connect(req: req);
+    _initializeEventsStream(instance!);
+    _subscribeToSdkStreams(instance!);
+    await _fetchWalletData(instance!);
+    return instance!;
   }
 
   void disconnect(liquid_sdk.BindingLiquidSdk sdk) {

--- a/lib/bloc/account/payment_result.dart
+++ b/lib/bloc/account/payment_result.dart
@@ -1,7 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/utils/exceptions.dart';
-import 'package:flutter/cupertino.dart';
 
 class PaymentResult {
   final Payment? paymentInfo;

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:l_breez/bloc/account/breez_liquid_sdk.dart';
 import 'package:l_breez/bloc/backup/backup_state.dart';
-import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:logging/logging.dart';
 
 class BackupBloc extends Cubit<BackupState?> {

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -22,7 +22,7 @@ class BackupBloc extends Cubit<BackupState?> {
   Future<void> backup() async {
     try {
       emit(BackupState(status: BackupStatus.INPROGRESS));
-      _liquidSDK.wallet?.backup(req: const BackupRequest());
+      _liquidSDK.instance?.backup(req: const BackupRequest());
       emit(BackupState(status: BackupStatus.SUCCESS));
     } catch (e) {
       _log.info("Failed to backup");

--- a/lib/bloc/currency/currency_bloc.dart
+++ b/lib/bloc/currency/currency_bloc.dart
@@ -25,7 +25,7 @@ class CurrencyBloc extends Cubit<CurrencyState> with HydratedMixin {
   }
 
   void listFiatCurrencies() {
-    liquidSdk.wallet!.listFiatCurrencies().then((fiatCurrencies) {
+    liquidSdk.instance!.listFiatCurrencies().then((fiatCurrencies) {
       emit(state.copyWith(
           fiatCurrenciesData: _sortedFiatCurrenciesList(
         fiatCurrencies,
@@ -56,7 +56,7 @@ class CurrencyBloc extends Cubit<CurrencyState> with HydratedMixin {
   }
 
   Future<Map<String, Rate>> fetchExchangeRates() async {
-    final List<Rate> rates = await liquidSdk.wallet!.fetchFiatRates();
+    final List<Rate> rates = await liquidSdk.instance!.fetchFiatRates();
     final exchangeRates = rates.fold<Map<String, Rate>>({}, (map, rate) {
       map[rate.coin] = rate;
       return map;

--- a/lib/bloc/security/security_bloc.dart
+++ b/lib/bloc/security/security_bloc.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
-import 'package:l_breez/bloc/security/security_state.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_fgbg/flutter_fgbg.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:l_breez/bloc/security/security_state.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:local_auth_android/local_auth_android.dart';
 import 'package:local_auth_darwin/types/auth_messages_ios.dart';

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -74,7 +74,7 @@ extension ConfigCopyWith on liquid_sdk.Config {
     String? workingDir,
     liquid_sdk.LiquidNetwork? network,
     BigInt? paymentTimeoutSec,
-    double? zeroConfMinFeeRate,
+    int? zeroConfMinFeeRateMsat,
   }) {
     return liquid_sdk.Config(
       liquidElectrumUrl: liquidElectrumUrl ?? this.liquidElectrumUrl,
@@ -82,7 +82,7 @@ extension ConfigCopyWith on liquid_sdk.Config {
       workingDir: workingDir ?? this.workingDir,
       network: network ?? this.network,
       paymentTimeoutSec: paymentTimeoutSec ?? this.paymentTimeoutSec,
-      zeroConfMinFeeRate: zeroConfMinFeeRate ?? this.zeroConfMinFeeRate,
+      zeroConfMinFeeRateMsat: zeroConfMinFeeRateMsat ?? this.zeroConfMinFeeRateMsat,
     );
   }
 }

--- a/lib/handlers/input_handler.dart
+++ b/lib/handlers/input_handler.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/input/input_bloc.dart';
 import 'package:l_breez/bloc/input/input_source.dart';
 import 'package:l_breez/bloc/input/input_state.dart';
@@ -11,8 +13,6 @@ import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/widgets/flushbar.dart';
 import 'package:l_breez/widgets/loader.dart';
 import 'package:l_breez/widgets/payment_dialogs/payment_request_dialog.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger("InputHandler");

--- a/lib/handlers/node_connectivity_handler.dart
+++ b/lib/handlers/node_connectivity_handler.dart
@@ -2,13 +2,13 @@ import 'dart:async';
 
 import 'package:another_flushbar/flushbar.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
 import 'package:l_breez/handlers/handler.dart';
 import 'package:l_breez/handlers/handler_context_provider.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger("NodeConnectivityHandler");

--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -3,12 +3,12 @@ library breez.logger;
 import 'dart:io';
 
 import 'package:archive/archive_io.dart';
-import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
-import 'package:l_breez/bloc/account/breez_liquid_sdk.dart';
-import 'package:l_breez/config.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
 import 'package:git_info/git_info.dart';
+import 'package:l_breez/bloc/account/breez_liquid_sdk.dart';
+import 'package:l_breez/config.dart';
 import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/bloc/account/credentials_manager.dart';
@@ -22,7 +23,6 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preference_app_group/shared_preference_app_group.dart';
-import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
 
 final _log = Logger("Main");
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,7 +42,7 @@ void main() async {
     var breezLogger = injector.breezLogger;
 
     // Initialize Log Stream
-    if (injector.liquidSDK.wallet == null) {
+    if (injector.liquidSDK.instance == null) {
       injector.liquidSDK.initializeLogStream();
       breezLogger.registerBreezLiquidSdkLogs(injector.liquidSDK);
     }

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -3,6 +3,8 @@
 import 'dart:async';
 
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/input/input_bloc.dart';
 import 'package:l_breez/bloc/input/input_state.dart';
@@ -12,8 +14,6 @@ import 'package:l_breez/routes/create_invoice/widgets/loading_or_error.dart';
 import 'package:l_breez/services/injector.dart';
 import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/widgets/flushbar.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
 

--- a/lib/routes/create_invoice/widgets/expiry_and_fee_message.dart
+++ b/lib/routes/create_invoice/widgets/expiry_and_fee_message.dart
@@ -1,10 +1,10 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/currency/currency_bloc.dart';
 import 'package:l_breez/bloc/currency/currency_state.dart';
 import 'package:l_breez/theme/theme_extensions.dart';
 import 'package:l_breez/widgets/warning_box.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 
 final log = Logger("ExpiryAndFeeMessage");

--- a/lib/routes/create_invoice/widgets/invoice_qr.dart
+++ b/lib/routes/create_invoice/widgets/invoice_qr.dart
@@ -1,5 +1,5 @@
-import 'package:l_breez/routes/create_invoice/widgets/compact_qr_image.dart';
 import 'package:flutter/material.dart';
+import 'package:l_breez/routes/create_invoice/widgets/compact_qr_image.dart';
 
 class InvoiceQR extends StatelessWidget {
   final String bolt11;

--- a/lib/routes/create_invoice/widgets/particle_model.dart
+++ b/lib/routes/create_invoice/widgets/particle_model.dart
@@ -1,8 +1,8 @@
 import 'dart:math';
 
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/create_invoice/widgets/animation_progress.dart';
 import 'package:l_breez/routes/create_invoice/widgets/animation_properties.dart';
-import 'package:flutter/material.dart';
 import 'package:simple_animations/simple_animations.dart';
 
 class ParticleModel {

--- a/lib/routes/create_invoice/widgets/particle_painter.dart
+++ b/lib/routes/create_invoice/widgets/particle_painter.dart
@@ -1,6 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/create_invoice/widgets/animation_properties.dart';
 import 'package:l_breez/routes/create_invoice/widgets/particle_model.dart';
-import 'package:flutter/material.dart';
 import 'package:simple_animations/simple_animations.dart';
 
 class ParticlePainter extends CustomPainter {

--- a/lib/routes/create_invoice/widgets/particles_animations.dart
+++ b/lib/routes/create_invoice/widgets/particles_animations.dart
@@ -1,8 +1,8 @@
 import 'dart:math';
 
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/create_invoice/widgets/particle_model.dart';
 import 'package:l_breez/routes/create_invoice/widgets/particle_painter.dart';
-import 'package:flutter/material.dart';
 import 'package:simple_animations/simple_animations.dart';
 
 class Particles extends StatefulWidget {

--- a/lib/routes/create_invoice/widgets/successful_payment.dart
+++ b/lib/routes/create_invoice/widgets/successful_payment.dart
@@ -1,6 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/create_invoice/widgets/particles_animations.dart';
 import 'package:l_breez/routes/create_invoice/widgets/successful_payment_dialog.dart';
-import 'package:flutter/material.dart';
 
 class SuccessfulPaymentRoute extends StatefulWidget {
   final Function()? onPrint;

--- a/lib/routes/create_invoice/widgets/successful_payment_dialog.dart
+++ b/lib/routes/create_invoice/widgets/successful_payment_dialog.dart
@@ -1,7 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/routes/create_invoice/widgets/successful_payment_message.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:l_breez/routes/create_invoice/widgets/successful_payment_message.dart';
 
 class SuccessfulPaymentDialog extends StatelessWidget {
   final Function()? onPrint;

--- a/lib/routes/dev/command_line_interface.dart
+++ b/lib/routes/dev/command_line_interface.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/dev/widget/command_list.dart';
 import 'package:l_breez/services/injector.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
-import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';

--- a/lib/routes/dev/widget/command_list.dart
+++ b/lib/routes/dev/widget/command_list.dart
@@ -1,6 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/dev/widget/command.dart';
 import 'package:l_breez/widgets/loader.dart';
-import 'package:flutter/material.dart';
 
 class CommandList extends StatelessWidget {
   final bool loading;

--- a/lib/routes/fiat_currencies/fiat_currency_settings.dart
+++ b/lib/routes/fiat_currencies/fiat_currency_settings.dart
@@ -1,15 +1,15 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/currency/currency_bloc.dart';
 import 'package:l_breez/bloc/currency/currency_state.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/back_button.dart' as back_button;
 import 'package:l_breez/widgets/loader.dart';
-import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 const double ITEM_HEIGHT = 72.0;
 

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
@@ -12,8 +14,6 @@ import 'package:l_breez/routes/home/widgets/payments_filter/payments_filter_sliv
 import 'package:l_breez/routes/home/widgets/payments_list/payments_list.dart';
 import 'package:l_breez/routes/home/widgets/status_text.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 
 const _kFilterMaxSize = 64.0;

--- a/lib/routes/home/widgets/animated_loader_dialog.dart
+++ b/lib/routes/home/widgets/animated_loader_dialog.dart
@@ -1,7 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/theme/theme_provider.dart';
 import 'package:l_breez/widgets/loading_animated_text.dart';
-import 'package:flutter/material.dart';
 
 AlertDialog createAnimatedLoaderDialog(
   BuildContext context,

--- a/lib/routes/home/widgets/app_bar/account_required_actions.dart
+++ b/lib/routes/home/widgets/app_bar/account_required_actions.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
 import 'package:l_breez/bloc/account/credentials_manager.dart';
@@ -9,7 +10,6 @@ import 'package:l_breez/routes/home/widgets/enable_backup_dialog.dart';
 import 'package:l_breez/routes/home/widgets/rotator.dart';
 import 'package:l_breez/services/injector.dart';
 import 'package:l_breez/widgets/backup_in_progress_dialog.dart';
-import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger("AccountRequiredActionsIndicator");

--- a/lib/routes/home/widgets/bottom_actions_bar/bottom_action_item.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/bottom_action_item.dart
@@ -1,6 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 class BottomActionItem extends StatelessWidget {
   final String text;

--- a/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
@@ -1,9 +1,9 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:l_breez/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart';
 import 'package:l_breez/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart';
-import 'package:flutter/material.dart';
 
 import 'bottom_action_item.dart';
 

--- a/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
@@ -1,12 +1,12 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/input/input_bloc.dart';
 import 'package:l_breez/bloc/input/input_source.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/flushbar.dart';
 import 'package:l_breez/widgets/loader.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger("EnterPaymentInfoDialog");

--- a/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
@@ -1,6 +1,6 @@
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 import 'bottom_action_item_image.dart';
 

--- a/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
@@ -1,8 +1,8 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/home/widgets/bottom_actions_bar/bottom_action_item_image.dart';
 import 'package:l_breez/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
-import 'package:flutter/material.dart';
 
 class SendOptionsBottomSheet extends StatefulWidget {
   final GlobalKey firstPaymentItemKey;

--- a/lib/routes/home/widgets/bubble_painter.dart
+++ b/lib/routes/home/widgets/bubble_painter.dart
@@ -1,5 +1,5 @@
-import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 const double _kBubbleRadius = 12;
 

--- a/lib/routes/home/widgets/dashboard/balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/balance_text.dart
@@ -1,9 +1,9 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
 import 'package:l_breez/bloc/currency/currency_state.dart';
 import 'package:l_breez/bloc/user_profile/user_profile_state.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
-import 'package:flutter/material.dart';
 
 class BalanceText extends StatefulWidget {
   final UserProfileState userProfileState;

--- a/lib/routes/home/widgets/dashboard/fiat_balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/fiat_balance_text.dart
@@ -1,12 +1,12 @@
 import 'dart:math';
 
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
 import 'package:l_breez/bloc/currency/currency_bloc.dart';
 import 'package:l_breez/bloc/currency/currency_state.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/utils/fiat_conversion.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class FiatBalanceText extends StatefulWidget {
   final CurrencyState currencyState;

--- a/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
+++ b/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
 import 'package:l_breez/bloc/currency/currency_bloc.dart';
@@ -7,8 +9,6 @@ import 'package:l_breez/bloc/user_profile/user_profile_state.dart';
 import 'package:l_breez/models/currency.dart';
 import 'package:l_breez/routes/home/widgets/dashboard/fiat_balance_text.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'balance_text.dart';
 

--- a/lib/routes/home/widgets/drawer/breez_avatar_dialog.dart
+++ b/lib/routes/home/widgets/drawer/breez_avatar_dialog.dart
@@ -2,6 +2,11 @@ import 'dart:async';
 
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:image/image.dart' as dart_image;
+import 'package:image_cropper/image_cropper.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:l_breez/bloc/user_profile/default_profile_generator.dart';
 import 'package:l_breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:l_breez/bloc/user_profile/user_profile_state.dart';
@@ -9,11 +14,6 @@ import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/utils/min_font_size.dart';
 import 'package:l_breez/widgets/breez_avatar.dart';
 import 'package:l_breez/widgets/flushbar.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:image/image.dart' as dart_image;
-import 'package:image_cropper/image_cropper.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger("BreezAvatarDialog");

--- a/lib/routes/home/widgets/drawer/breez_navigation_drawer.dart
+++ b/lib/routes/home/widgets/drawer/breez_navigation_drawer.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:l_breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:l_breez/bloc/user_profile/user_profile_state.dart';
@@ -11,8 +13,6 @@ import 'package:l_breez/routes/home/widgets/drawer/breez_avatar_dialog.dart';
 import 'package:l_breez/routes/home/widgets/drawer/breez_drawer_header.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/breez_avatar.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:theme_provider/theme_provider.dart';
 
 const double _kBreezBottomSheetHeight = 60.0;

--- a/lib/routes/home/widgets/drawer/home_drawer.dart
+++ b/lib/routes/home/widgets/drawer/home_drawer.dart
@@ -1,11 +1,11 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:l_breez/bloc/user_profile/user_profile_state.dart';
 import 'package:l_breez/models/user_profile.dart';
 import 'package:l_breez/routes/home/widgets/drawer/breez_navigation_drawer.dart';
 import 'package:l_breez/widgets/flushbar.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class HomeDrawer extends StatefulWidget {
   const HomeDrawer({super.key});

--- a/lib/routes/home/widgets/enable_backup_dialog.dart
+++ b/lib/routes/home/widgets/enable_backup_dialog.dart
@@ -1,9 +1,9 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/bloc/backup/backup_bloc.dart';
-import 'package:l_breez/utils/min_font_size.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:l_breez/bloc/backup/backup_bloc.dart';
+import 'package:l_breez/utils/min_font_size.dart';
 
 class EnableBackupDialog extends StatefulWidget {
   const EnableBackupDialog({super.key});

--- a/lib/routes/home/widgets/payments_filter/calendar_dialog.dart
+++ b/lib/routes/home/widgets/payments_filter/calendar_dialog.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/utils/date.dart';
-import 'package:flutter/material.dart';
 
 class CalendarDialog extends StatefulWidget {
   final DateTime firstDate;

--- a/lib/routes/home/widgets/payments_filter/header_filter_chip.dart
+++ b/lib/routes/home/widgets/payments_filter/header_filter_chip.dart
@@ -1,8 +1,8 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/utils/date.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'fixed_sliver_delegate.dart';
 

--- a/lib/routes/home/widgets/payments_filter/payment_filter_exporter.dart
+++ b/lib/routes/home/widgets/payments_filter/payment_filter_exporter.dart
@@ -1,4 +1,6 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
@@ -7,8 +9,6 @@ import 'package:l_breez/bloc/currency/currency_bloc.dart';
 import 'package:l_breez/theme/theme_provider.dart';
 import 'package:l_breez/widgets/flushbar.dart';
 import 'package:l_breez/widgets/loader.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
 

--- a/lib/routes/home/widgets/payments_filter/payments_filter.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter.dart
@@ -1,12 +1,12 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
 import 'package:l_breez/routes/home/widgets/payments_filter/payment_filter_exporter.dart';
 import 'package:l_breez/routes/home/widgets/payments_filter/payments_filter_calendar.dart';
 import 'package:l_breez/routes/home/widgets/payments_filter/payments_filter_dropdown.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class PaymentsFilters extends StatefulWidget {
   const PaymentsFilters({

--- a/lib/routes/home/widgets/payments_filter/payments_filter_calendar.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter_calendar.dart
@@ -1,12 +1,12 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
 import 'package:l_breez/routes/home/widgets/payments_filter/calendar_dialog.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_svg/svg.dart';
 
 class PaymentsFilterCalendar extends StatelessWidget {
   final List<PaymentType> filter;

--- a/lib/routes/home/widgets/payments_filter/payments_filter_dropdown.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter_dropdown.dart
@@ -1,6 +1,6 @@
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 class PaymentsFilterDropdown extends StatelessWidget {
   final String filter;

--- a/lib/routes/home/widgets/payments_filter/payments_filter_sliver.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter_sliver.dart
@@ -1,7 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/home/widgets/payments_filter/fixed_sliver_delegate.dart';
 import 'package:l_breez/routes/home/widgets/payments_filter/payments_filter.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
-import 'package:flutter/material.dart';
 
 class PaymentsFilterSliver extends StatefulWidget {
   final double maxSize;

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_amount.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_amount.dart
@@ -1,12 +1,12 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/currency/currency_bloc.dart';
 import 'package:l_breez/bloc/currency/currency_state.dart';
 import 'package:l_breez/models/currency.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class PaymentDetailsDialogAmount extends StatelessWidget {
   final PaymentMinutiae paymentMinutiae;

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_content_title.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_content_title.dart
@@ -1,6 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:l_breez/models/payment_minutiae.dart';
 import 'package:flutter/material.dart';
+import 'package:l_breez/models/payment_minutiae.dart';
 
 class PaymentDetailsDialogContentTitle extends StatelessWidget {
   final PaymentMinutiae paymentMinutiae;

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_date.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_date.dart
@@ -1,8 +1,8 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
 import 'package:l_breez/utils/date.dart';
-import 'package:flutter/material.dart';
 
 class PaymentDetailsDialogDate extends StatelessWidget {
   final PaymentMinutiae paymentMinutiae;

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_destination_pubkey.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_destination_pubkey.dart
@@ -1,7 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart';
-import 'package:flutter/material.dart';
 
 class PaymentDetailsDestinationPubkey extends StatelessWidget {
   final PaymentMinutiae paymentMinutiae;

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_preimage.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_preimage.dart
@@ -1,7 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart';
-import 'package:flutter/material.dart';
 
 class PaymentDetailsPreimage extends StatelessWidget {
   final PaymentMinutiae paymentMinutiae;

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_title.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_title.dart
@@ -1,7 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/payment_item_avatar.dart';
 import 'package:l_breez/theme/theme_extensions.dart';
-import 'package:flutter/material.dart';
 
 class PaymentDetailsDialogTitle extends StatelessWidget {
   final PaymentMinutiae paymentMinutiae;

--- a/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
@@ -1,9 +1,9 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/services/injector.dart';
 import 'package:l_breez/utils/external_browser.dart';
 import 'package:l_breez/widgets/flushbar.dart';
-import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 
 class ShareablePaymentRow extends StatelessWidget {

--- a/lib/routes/home/widgets/payments_list/dialog/tx_widget.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/tx_widget.dart
@@ -1,8 +1,8 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/services/injector.dart';
 import 'package:l_breez/widgets/flushbar.dart';
 import 'package:l_breez/widgets/link_launcher.dart';
-import 'package:flutter/material.dart';
 
 // TODO: Liquid - This file is unused - Re-add for swap tx's after input parser is implemented
 class TxWidget extends StatelessWidget {

--- a/lib/routes/home/widgets/payments_list/flip_transition.dart
+++ b/lib/routes/home/widgets/payments_list/flip_transition.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 class FlipTransition extends StatefulWidget {
   final Widget firstChild;

--- a/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
+++ b/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_amount.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_content_title.dart';
@@ -6,7 +7,6 @@ import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_destination_pubkey.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_preimage.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_title.dart';
-import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 
 final AutoSizeGroup _labelGroup = AutoSizeGroup();

--- a/lib/routes/home/widgets/payments_list/payment_item.dart
+++ b/lib/routes/home/widgets/payments_list/payment_item.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/flip_transition.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/payment_details_dialog.dart';
@@ -7,7 +8,6 @@ import 'package:l_breez/routes/home/widgets/payments_list/payment_item_subtitle.
 import 'package:l_breez/routes/home/widgets/payments_list/payment_item_title.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/success_avatar.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
-import 'package:flutter/material.dart';
 
 class PaymentItem extends StatefulWidget {
   final PaymentMinutiae _paymentMinutiae;

--- a/lib/routes/home/widgets/payments_list/payment_item_avatar.dart
+++ b/lib/routes/home/widgets/payments_list/payment_item_avatar.dart
@@ -1,7 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
 import 'package:l_breez/widgets/breez_avatar.dart';
-import 'package:flutter/material.dart';
 
 class PaymentItemAvatar extends StatelessWidget {
   final PaymentMinutiae paymentMinutiae;

--- a/lib/routes/home/widgets/payments_list/payment_item_subtitle.dart
+++ b/lib/routes/home/widgets/payments_list/payment_item_subtitle.dart
@@ -1,9 +1,9 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/utils/date.dart';
-import 'package:flutter/material.dart';
 
 class PaymentItemSubtitle extends StatelessWidget {
   final PaymentMinutiae _paymentMinutiae;

--- a/lib/routes/home/widgets/qr_action_button.dart
+++ b/lib/routes/home/widgets/qr_action_button.dart
@@ -1,11 +1,11 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:l_breez/bloc/input/input_bloc.dart';
 import 'package:l_breez/bloc/input/input_source.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/flushbar.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger("QrActionButton");

--- a/lib/routes/home/widgets/status_text.dart
+++ b/lib/routes/home/widgets/status_text.dart
@@ -1,10 +1,10 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
 import 'package:l_breez/theme/theme_provider.dart';
 import 'package:l_breez/utils/min_font_size.dart';
 import 'package:l_breez/widgets/loading_animated_text.dart';
-import 'package:flutter/material.dart';
 
 class StatusText extends StatelessWidget {
   final AccountState accountState;

--- a/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
@@ -1,7 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/initial_walkthrough/mnemonics/widgets/restore_form_page.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
-import 'package:flutter/material.dart';
 
 class EnterMnemonicsPage extends StatefulWidget {
   final List<String> initialWords;

--- a/lib/routes/initial_walkthrough/mnemonics/mnemonics_confirmation_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/mnemonics_confirmation_page.dart
@@ -1,11 +1,11 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/initial_walkthrough/mnemonics/mnemonics_page.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/back_button.dart' as back_button;
 import 'package:l_breez/widgets/route.dart';
 import 'package:l_breez/widgets/single_button_bottom_bar.dart';
-import 'package:flutter/material.dart';
 
 class MnemonicsConfirmationPage extends StatefulWidget {
   final String mnemonics;

--- a/lib/routes/initial_walkthrough/mnemonics/mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/mnemonics_page.dart
@@ -1,10 +1,10 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/initial_walkthrough/mnemonics/widgets/mnemonic_seed_list.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
 import 'package:l_breez/widgets/route.dart';
 import 'package:l_breez/widgets/single_button_bottom_bar.dart';
-import 'package:flutter/material.dart';
 
 import 'verify_mnemonics_page.dart';
 

--- a/lib/routes/initial_walkthrough/mnemonics/verify_mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/verify_mnemonics_page.dart
@@ -1,12 +1,12 @@
 import 'dart:math';
 
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/back_button.dart' as back_button;
 import 'package:l_breez/widgets/single_button_bottom_bar.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'widgets/verify_form.dart';
 

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/mnemonic_item.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/mnemonic_item.dart
@@ -1,8 +1,8 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/utils/min_font_size.dart';
-import 'package:flutter/material.dart';
 
 class MnemonicItem extends StatelessWidget {
   final String mnemonic;

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/theme/theme_provider.dart' as theme;
-import 'package:l_breez/utils/wordlist.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
+import 'package:l_breez/utils/wordlist.dart';
 
 class RestoreForm extends StatefulWidget {
   final GlobalKey formKey;

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form_page.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart';
 import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/widgets/single_button_bottom_bar.dart';
-import 'package:flutter/material.dart';
 
 class RestoreFormPage extends StatefulWidget {
   final int currentPage;

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/verify_form.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/verify_form.dart
@@ -1,6 +1,6 @@
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 class VerifyForm extends StatefulWidget {
   final GlobalKey<FormState> formKey;

--- a/lib/routes/qr_scan/widgets/qr_scan.dart
+++ b/lib/routes/qr_scan/widgets/qr_scan.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/routes/qr_scan/scan_overlay.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:l_breez/routes/qr_scan/scan_overlay.dart';
 import 'package:logging/logging.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 

--- a/lib/routes/security/auto_lock_mixin.dart
+++ b/lib/routes/security/auto_lock_mixin.dart
@@ -1,9 +1,9 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/security/security_bloc.dart';
 import 'package:l_breez/bloc/security/security_state.dart' as security;
 import 'package:l_breez/routes/security/lock_screen.dart';
 import 'package:l_breez/widgets/route.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 mixin AutoLockMixin<T extends StatefulWidget> on State<T> {
   @override

--- a/lib/routes/security/change_pin_page.dart
+++ b/lib/routes/security/change_pin_page.dart
@@ -1,13 +1,13 @@
 import 'dart:io';
 
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:l_breez/bloc/security/security_bloc.dart';
 import 'package:l_breez/routes/security/widget/pin_code_widget.dart';
 import 'package:l_breez/theme/breez_light_theme.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 

--- a/lib/routes/security/lock_screen.dart
+++ b/lib/routes/security/lock_screen.dart
@@ -1,14 +1,14 @@
 import 'dart:io';
 
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:l_breez/bloc/security/security_bloc.dart';
 import 'package:l_breez/bloc/security/security_state.dart';
 import 'package:l_breez/routes/security/widget/pin_code_widget.dart';
 import 'package:l_breez/theme/breez_light_theme.dart';
 import 'package:l_breez/widgets/route.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 

--- a/lib/routes/security/secured_page.dart
+++ b/lib/routes/security/secured_page.dart
@@ -1,9 +1,9 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/security/security_bloc.dart';
 import 'package:l_breez/bloc/security/security_state.dart';
 import 'package:l_breez/routes/security/widget/pin_code_widget.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger("SecuredPage");

--- a/lib/routes/security/security_page.dart
+++ b/lib/routes/security/security_page.dart
@@ -1,9 +1,9 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/security/widget/mnemonics/security_mnemonics_management.dart';
 import 'package:l_breez/routes/security/widget/security_pin_management.dart';
 import 'package:l_breez/theme/breez_light_theme.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
-import 'package:flutter/material.dart';
 
 class SecurityPage extends StatelessWidget {
   const SecurityPage({

--- a/lib/routes/security/widget/digit_button_widget.dart
+++ b/lib/routes/security/widget/digit_button_widget.dart
@@ -1,5 +1,5 @@
-import 'package:l_breez/widgets/preview/preview.dart';
 import 'package:flutter/material.dart';
+import 'package:l_breez/widgets/preview/preview.dart';
 
 class DigitButtonWidget extends StatelessWidget {
   final String? digit;

--- a/lib/routes/security/widget/digit_masked_widget.dart
+++ b/lib/routes/security/widget/digit_masked_widget.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:l_breez/widgets/preview/preview.dart';
 import 'package:flutter/material.dart';
+import 'package:l_breez/widgets/preview/preview.dart';
 
 class DigitMaskedWidget extends StatelessWidget {
   final double size;

--- a/lib/routes/security/widget/local_auth_switch.dart
+++ b/lib/routes/security/widget/local_auth_switch.dart
@@ -1,9 +1,9 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/security/security_bloc.dart';
 import 'package:l_breez/bloc/security/security_state.dart';
 import 'package:l_breez/widgets/designsystem/switch/simple_switch.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class LocalAuthSwitch extends StatelessWidget {
   const LocalAuthSwitch({

--- a/lib/routes/security/widget/mnemonics/security_mnemonics_management.dart
+++ b/lib/routes/security/widget/mnemonics/security_mnemonics_management.dart
@@ -1,12 +1,12 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
 import 'package:l_breez/bloc/account/credentials_manager.dart';
 import 'package:l_breez/routes/initial_walkthrough/mnemonics/mnemonics_page.dart';
 import 'package:l_breez/services/injector.dart';
 import 'package:l_breez/widgets/route.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SecurityMnemonicsManagement extends StatelessWidget {
   const SecurityMnemonicsManagement({

--- a/lib/routes/security/widget/num_pad_widget.dart
+++ b/lib/routes/security/widget/num_pad_widget.dart
@@ -1,6 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/security/widget/digit_button_widget.dart';
 import 'package:l_breez/widgets/preview/preview.dart';
-import 'package:flutter/material.dart';
 
 class NumPadWidget extends StatelessWidget {
   final ActionKey lhsActionKey;

--- a/lib/routes/security/widget/pin_code_widget.dart
+++ b/lib/routes/security/widget/pin_code_widget.dart
@@ -1,13 +1,13 @@
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:l_breez/bloc/security/security_state.dart';
 import 'package:l_breez/routes/security/widget/digit_masked_widget.dart';
 import 'package:l_breez/routes/security/widget/num_pad_widget.dart';
 import 'package:l_breez/widgets/preview/preview.dart';
 import 'package:l_breez/widgets/shake_widget.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 
 class PinCodeWidget extends StatefulWidget {
   final int pinLength;

--- a/lib/routes/security/widget/security_pin_interval.dart
+++ b/lib/routes/security/widget/security_pin_interval.dart
@@ -1,11 +1,11 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
-import 'package:l_breez/bloc/security/security_bloc.dart';
-import 'package:l_breez/widgets/preview/preview.dart';
 import 'package:duration/duration.dart';
 import 'package:duration/locale.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:l_breez/bloc/security/security_bloc.dart';
+import 'package:l_breez/widgets/preview/preview.dart';
 
 class SecurityPinInterval extends StatelessWidget {
   final Duration interval;

--- a/lib/routes/security/widget/security_pin_management.dart
+++ b/lib/routes/security/widget/security_pin_management.dart
@@ -1,6 +1,9 @@
 import 'dart:io';
 
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:l_breez/bloc/security/security_bloc.dart';
 import 'package:l_breez/bloc/security/security_state.dart';
 import 'package:l_breez/routes/security/change_pin_page.dart';
@@ -9,9 +12,6 @@ import 'package:l_breez/routes/security/widget/security_pin_interval.dart';
 import 'package:l_breez/widgets/designsystem/switch/simple_switch.dart';
 import 'package:l_breez/widgets/preview/preview.dart';
 import 'package:l_breez/widgets/route.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -1,7 +1,7 @@
 // Color(0xFF121212) values are tbd
-import 'package:l_breez/theme/theme_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:l_breez/theme/theme_extensions.dart';
 
 import 'breez_colors.dart';
 

--- a/lib/theme/theme_extensions.dart
+++ b/lib/theme/theme_extensions.dart
@@ -1,5 +1,5 @@
-import 'package:l_breez/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme_provider.dart';
 
 class FieldTextStyle {
   FieldTextStyle._();

--- a/lib/utils/currency_formatter.dart
+++ b/lib/utils/currency_formatter.dart
@@ -1,7 +1,7 @@
-import 'package:l_breez/models/currency.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/number_symbols.dart';
 import 'package:intl/number_symbols_data.dart';
+import 'package:l_breez/models/currency.dart';
 
 class CurrencyFormatter {
   final NumberFormat formatter = _defineFormatter();

--- a/lib/utils/external_browser.dart
+++ b/lib/utils/external_browser.dart
@@ -1,7 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/widgets/loader.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:l_breez/widgets/loader.dart';
 import 'package:logging/logging.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 

--- a/lib/utils/preferences.dart
+++ b/lib/utils/preferences.dart
@@ -1,5 +1,5 @@
-import 'package:l_breez/models/bug_report_behavior.dart';
 import 'package:flutter/foundation.dart';
+import 'package:l_breez/models/bug_report_behavior.dart';
 import 'package:logging/logging.dart';
 import 'package:shared_preference_app_group/shared_preference_app_group.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/widgets/address_qr_widget.dart
+++ b/lib/widgets/address_qr_widget.dart
@@ -1,9 +1,9 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/routes/create_invoice/widgets/compact_qr_image.dart';
 import 'package:l_breez/services/injector.dart';
 import 'package:l_breez/widgets/address_widget.dart';
 import 'package:l_breez/widgets/flushbar.dart';
-import 'package:flutter/material.dart';
 
 class AddressQRWidget extends StatelessWidget {
   final String address;

--- a/lib/widgets/address_widget.dart
+++ b/lib/widgets/address_widget.dart
@@ -1,9 +1,9 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/services/injector.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/address_qr_widget.dart';
 import 'package:l_breez/widgets/flushbar.dart';
-import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 
 enum AddressWidgetType {

--- a/lib/widgets/amount_form_field/currency_converter_dialog.dart
+++ b/lib/widgets/amount_form_field/currency_converter_dialog.dart
@@ -1,5 +1,8 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/bloc/currency/currency_bloc.dart';
 import 'package:l_breez/bloc/currency/currency_state.dart';
@@ -8,9 +11,6 @@ import 'package:l_breez/utils/fiat_conversion.dart';
 import 'package:l_breez/utils/min_font_size.dart';
 import 'package:l_breez/widgets/flushbar.dart';
 import 'package:l_breez/widgets/loader.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CurrencyConverterDialog extends StatefulWidget {
   final Function(String string) _onConvert;

--- a/lib/widgets/amount_form_field/sat_amount_form_field_formatter.dart
+++ b/lib/widgets/amount_form_field/sat_amount_form_field_formatter.dart
@@ -1,5 +1,5 @@
-import 'package:l_breez/models/currency.dart';
 import 'package:flutter/services.dart';
+import 'package:l_breez/models/currency.dart';
 
 class SatAmountFormFieldFormatter extends TextInputFormatter {
   final RegExp _pattern = RegExp(r'[^\d*]');

--- a/lib/widgets/backup_in_progress_dialog.dart
+++ b/lib/widgets/backup_in_progress_dialog.dart
@@ -1,9 +1,9 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/backup/backup_bloc.dart';
 import 'package:l_breez/bloc/backup/backup_state.dart';
 import 'package:l_breez/routes/home/widgets/animated_loader_dialog.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class BackupInProgressDialog extends StatefulWidget {
   const BackupInProgressDialog({super.key});

--- a/lib/widgets/breez_avatar.dart
+++ b/lib/widgets/breez_avatar.dart
@@ -1,12 +1,12 @@
 import 'dart:io';
 
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/bloc/user_profile/profile_animal.dart';
-import 'package:l_breez/bloc/user_profile/profile_color.dart';
-import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:l_breez/bloc/user_profile/profile_animal.dart';
+import 'package:l_breez/bloc/user_profile/profile_color.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 class BreezAvatar extends StatelessWidget {
   final String? avatarURL;

--- a/lib/widgets/designsystem/switch/simple_switch.dart
+++ b/lib/widgets/designsystem/switch/simple_switch.dart
@@ -1,6 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:l_breez/utils/min_font_size.dart';
 import 'package:flutter/material.dart';
+import 'package:l_breez/utils/min_font_size.dart';
 
 class SimpleSwitch extends StatelessWidget {
   final String text;

--- a/lib/widgets/flushbar.dart
+++ b/lib/widgets/flushbar.dart
@@ -1,7 +1,7 @@
 import 'package:another_flushbar/flushbar.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 Flushbar showFlushbar(
   BuildContext context, {

--- a/lib/widgets/keyboard_done_action.dart
+++ b/lib/widgets/keyboard_done_action.dart
@@ -1,7 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 const double _kBarSize = 45.0;
 

--- a/lib/widgets/link_launcher.dart
+++ b/lib/widgets/link_launcher.dart
@@ -1,6 +1,6 @@
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:l_breez/utils/external_browser.dart';
 import 'package:flutter/material.dart';
+import 'package:l_breez/utils/external_browser.dart';
 
 class LinkLauncher extends StatelessWidget {
   final double iconSize;

--- a/lib/widgets/loader.dart
+++ b/lib/widgets/loader.dart
@@ -1,6 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/transparent_page_route.dart';
-import 'package:flutter/material.dart';
 
 class Loader extends StatelessWidget {
   final double? value;

--- a/lib/widgets/payment_dialogs/payment_request_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_dialog.dart
@@ -1,10 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/models/invoice.dart';
 import 'package:l_breez/widgets/payment_dialogs/payment_confirmation_dialog.dart';
 import 'package:l_breez/widgets/payment_dialogs/payment_request_info_dialog.dart';
 import 'package:l_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 enum PaymentRequestState {
   PAYMENT_REQUEST,

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/bloc/account/account_bloc.dart';
 import 'package:l_breez/bloc/account/account_state.dart';
 import 'package:l_breez/bloc/currency/currency_bloc.dart';
@@ -12,8 +14,6 @@ import 'package:l_breez/utils/payment_validator.dart';
 import 'package:l_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:l_breez/widgets/breez_avatar.dart';
 import 'package:l_breez/widgets/keyboard_done_action.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class PaymentRequestInfoDialog extends StatefulWidget {
   final Invoice invoice;

--- a/lib/widgets/payment_dialogs/processing_payment/processing_payment_animated_content.dart
+++ b/lib/widgets/payment_dialogs/processing_payment/processing_payment_animated_content.dart
@@ -1,5 +1,5 @@
-import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 class ProcessingPaymentAnimatedContent extends StatelessWidget {
   final Color color;

--- a/lib/widgets/payment_dialogs/processing_payment/processing_payment_content.dart
+++ b/lib/widgets/payment_dialogs/processing_payment/processing_payment_content.dart
@@ -1,8 +1,8 @@
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/loading_animated_text.dart';
 import 'package:l_breez/widgets/payment_dialogs/processing_payment/processing_payment_title.dart';
-import 'package:flutter/material.dart';
 
 class ProcessingPaymentContent extends StatelessWidget {
   final GlobalKey? dialogKey;

--- a/lib/widgets/payment_dialogs/processing_payment_dialog.dart
+++ b/lib/widgets/payment_dialogs/processing_payment_dialog.dart
@@ -1,14 +1,14 @@
 import 'dart:async';
 
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/widgets/flushbar.dart';
 import 'package:l_breez/widgets/payment_dialogs/payment_request_dialog.dart';
 import 'package:l_breez/widgets/payment_dialogs/processing_payment/processing_payment_animated_content.dart';
 import 'package:l_breez/widgets/payment_dialogs/processing_payment/processing_payment_content.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 
 const _kPaymentListItemHeight = 72.0;
 

--- a/lib/widgets/preview/preview.dart
+++ b/lib/widgets/preview/preview.dart
@@ -1,6 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:l_breez/theme/theme_provider.dart';
 import 'package:l_breez/widgets/preview/fill_view_port_column_scroll_view.dart';
-import 'package:flutter/material.dart';
 
 class Preview extends StatefulWidget {
   final List<Widget> children;

--- a/lib/widgets/warning_box.dart
+++ b/lib/widgets/warning_box.dart
@@ -1,5 +1,5 @@
-import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 class WarningBox extends StatelessWidget {
   final EdgeInsets boxPadding;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -752,10 +752,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: f54946fdb1fa7b01f780841937b1a80783a20b393485f3f6cdf336fd6f4705f2
+      sha256: f9f6597ac43cc262fa7d7f2e65259a6060c23a560525d1f2631be374540f2a9b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   frontend_server_client:
     dependency: transitive
     description:
@@ -1034,10 +1034,10 @@ packages:
     dependency: "direct main"
     description:
       name: local_auth_android
-      sha256: "6b60f9f545af5b5a11a90af3c2ab4361c47fff170134fa1c6d4c7d52e6537174"
+      sha256: "33fcebe9c3cf1bb0033bc85caed354c1e75ff7f7670918a571bd3152a2b65bf4"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.41"
+    version: "1.0.42"
   local_auth_darwin:
     dependency: "direct main"
     description:
@@ -1194,10 +1194,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: bca87b0165ffd7cdb9cad8edd22d18d2201e886d9a9f19b4fb3452ea7df3a72a
+      sha256: "30c5aa827a6ae95ce2853cdc5fe3971daaac00f6f081c419c013f7f57bff2f5e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.6"
+    version: "2.2.7"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1623,10 +1623,10 @@ packages:
     dependency: "direct main"
     description:
       name: timeago
-      sha256: d3204eb4c788214883380253da7f23485320a58c11d145babc82ad16bf4e7764
+      sha256: "054cedf68706bb142839ba0ae6b135f6b68039f0b8301cbe8784ae653d5ff8de"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "3.7.0"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter_breez_liquid:
     git:
       url: https://github.com/breez/breez-liquid-sdk-flutter
-  flutter_rust_bridge: ^2.0.0
+  flutter_rust_bridge: 2.0.0
   breez_translations:
     git:
       url: https://github.com/breez/Breez-Translations
@@ -69,7 +69,7 @@ dependencies:
   intl: ^0.19.0
   # Doesn't support: Linux Mac
   local_auth: ^2.2.0
-  local_auth_android: ^1.0.41
+  local_auth_android: ^1.0.42
   local_auth_darwin: ^1.3.1
   logging: ^1.2.0
   mockito: ^5.4.4
@@ -90,7 +90,7 @@ dependencies:
   sqlite3_flutter_libs: ^0.5.24
   synchronized: ^3.1.0+1
   theme_provider: ^0.6.0
-  timeago: ^3.6.1
+  timeago: ^3.7.0
   # Doesn't support: Linux Mac Windows
   uni_links: ^0.5.1
   url_launcher: ^6.3.0


### PR DESCRIPTION
closes #31 

- Renamed `wallet` to `instance`
- Pins `flutter_rust_bridge` to `2.0.0`
- Apply SDK rename change; `zeroConfMinFeeRate` to `zeroConfMinFeeRateMsat`
- Updates dependencies to latest
- Optimized imports