### PR TITLE
List payments in reverse chronological order (newest to oldest)

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -332,7 +332,6 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
         );
       }).toList();
     }
-    // TODO: Liquid - Return chronologically sorted list
-    return filteredPayments.reversed.toList();
+    return filteredPayments;
   }
 }

--- a/lib/bloc/account/breez_sdk_liquid.dart
+++ b/lib/bloc/account/breez_sdk_liquid.dart
@@ -23,7 +23,7 @@ class BreezSDKLiquid {
 
   Future _fetchWalletData(liquid_sdk.BindingLiquidSdk sdk) async {
     await _getInfo(sdk);
-    await _listPayments(sdk);
+    await _listPayments(sdk: sdk, req: const liquid_sdk.ListPaymentsRequest());
   }
 
   Future<liquid_sdk.GetInfoResponse> _getInfo(liquid_sdk.BindingLiquidSdk sdk) async {
@@ -32,8 +32,11 @@ class BreezSDKLiquid {
     return walletInfo;
   }
 
-  Future<List<liquid_sdk.Payment>> _listPayments(liquid_sdk.BindingLiquidSdk sdk) async {
-    final paymentsList = await sdk.listPayments();
+  Future<List<liquid_sdk.Payment>> _listPayments({
+    required liquid_sdk.BindingLiquidSdk sdk,
+    required liquid_sdk.ListPaymentsRequest req,
+  }) async {
+    final paymentsList = await sdk.listPayments(req: req);
     _paymentsController.add(paymentsList);
     return paymentsList;
   }

--- a/lib/bloc/account/breez_sdk_liquid.dart
+++ b/lib/bloc/account/breez_sdk_liquid.dart
@@ -35,7 +35,7 @@ class BreezSDKLiquid {
   Future<List<liquid_sdk.Payment>> _listPayments({
     required liquid_sdk.BindingLiquidSdk sdk,
   }) async {
-    final req = const liquid_sdk.ListPaymentsRequest();
+    const req = liquid_sdk.ListPaymentsRequest();
     final paymentsList = await sdk.listPayments(req: req);
     _paymentsController.add(paymentsList);
     return paymentsList;

--- a/lib/bloc/account/breez_sdk_liquid.dart
+++ b/lib/bloc/account/breez_sdk_liquid.dart
@@ -23,7 +23,7 @@ class BreezSDKLiquid {
 
   Future _fetchWalletData(liquid_sdk.BindingLiquidSdk sdk) async {
     await _getInfo(sdk);
-    await _listPayments(sdk: sdk, req: const liquid_sdk.ListPaymentsRequest());
+    await _listPayments(sdk: sdk);
   }
 
   Future<liquid_sdk.GetInfoResponse> _getInfo(liquid_sdk.BindingLiquidSdk sdk) async {
@@ -34,8 +34,8 @@ class BreezSDKLiquid {
 
   Future<List<liquid_sdk.Payment>> _listPayments({
     required liquid_sdk.BindingLiquidSdk sdk,
-    required liquid_sdk.ListPaymentsRequest req,
   }) async {
+    final req = const liquid_sdk.ListPaymentsRequest();
     final paymentsList = await sdk.listPayments(req: req);
     _paymentsController.add(paymentsList);
     return paymentsList;


### PR DESCRIPTION
This PR uses the default `ListPaymentsRequest` to call `listPayments` and removes list reversal workaround.