### PR TITLE
Add additional `Payment` details to `PaymentMinutiae`

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -112,8 +112,6 @@ PODS:
     - TOCropViewController (~> 2.7.4)
   - image_picker_ios (0.0.1):
     - Flutter
-  - integration_test (0.0.1):
-    - Flutter
   - local_auth_darwin (0.0.1):
     - Flutter
   - MLImage (1.0.0-beta5)
@@ -195,7 +193,6 @@ DEPENDENCIES:
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
-  - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -262,8 +259,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_cropper/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
-  integration_test:
-    :path: ".symlinks/plugins/integration_test/ios"
   local_auth_darwin:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
   mobile_scanner:
@@ -313,7 +308,6 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   image_cropper: 37d40f62177c101ff4c164906d259ea2c3aa70cf
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
   local_auth_darwin: 4d56c90c2683319835a61274b57620df9c4520ab
   MLImage: 1824212150da33ef225fbd3dc49f184cf611046c
   MLKitBarcodeScanning: 10ca0845a6d15f2f6e911f682a1998b68b973e8b

--- a/lib/models/payment_minutiae.dart
+++ b/lib/models/payment_minutiae.dart
@@ -8,36 +8,49 @@ class PaymentMinutiae {
   final String id;
   final String title;
   final String preimage;
+  final String bolt11;
   final String swapId;
+  final String txId;
+  final String refundTxId;
   final PaymentType paymentType;
   final DateTime paymentTime;
   final int feeSat;
   final int amountSat;
+  final int refundTxAmountSat;
   final PaymentState status;
 
   const PaymentMinutiae({
     required this.id,
     required this.title,
     required this.preimage,
+    required this.bolt11,
     required this.swapId,
+    required this.txId,
+    required this.refundTxId,
     required this.paymentType,
     required this.paymentTime,
     required this.feeSat,
     required this.amountSat,
+    required this.refundTxAmountSat,
     required this.status,
   });
 
   factory PaymentMinutiae.fromPayment(Payment payment, BreezTranslations texts) {
     final factory = _PaymentMinutiaeFactory(payment, texts);
+
     return PaymentMinutiae(
       id: payment.txId ?? "",
       title: factory._title(),
       preimage: payment.preimage ?? "",
+      bolt11: payment.bolt11 ?? "",
       swapId: payment.swapId ?? "",
+      txId: payment.txId ?? "",
+      refundTxId: payment.refundTxId ?? "",
       paymentType: payment.paymentType,
       paymentTime: factory._paymentTime(),
       feeSat: payment.feesSat.toInt(),
       amountSat: payment.amountSat.toInt(),
+      refundTxAmountSat: payment.refundTxAmountSat?.toInt() ?? 0,
       status: payment.status,
     );
   }
@@ -50,7 +63,11 @@ class _PaymentMinutiaeFactory {
   _PaymentMinutiaeFactory(this._payment, this._texts);
 
   String _title() {
-    return _texts.wallet_dashboard_payment_item_no_title;
+    var title = "${_texts.wallet_dashboard_payment_item_no_title} Payment";
+    if (_payment.bolt11 != null) return "Lightning Payment";
+    if (_payment.refundTxId != null) return "Refund Transaction";
+    if (_payment.swapId != null) return "Chain Swap Transaction";
+    return title;
   }
 
   DateTime _paymentTime() {

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_bolt11.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_bolt11.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:l_breez/models/payment_minutiae.dart';
+import 'package:l_breez/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart';
+
+class PaymentDetailsBolt11 extends StatelessWidget {
+  final PaymentMinutiae paymentMinutiae;
+
+  const PaymentDetailsBolt11({super.key, required this.paymentMinutiae});
+
+  @override
+  Widget build(BuildContext context) {
+    final bolt11 = paymentMinutiae.bolt11;
+    if (bolt11.isNotEmpty) {
+      return ShareablePaymentRow(
+        title: "Invoice",
+        sharedValue: bolt11,
+      );
+    } else {
+      return Container();
+    }
+  }
+}

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_refund_tx_fee_amount.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_refund_tx_fee_amount.dart
@@ -1,0 +1,69 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/models/currency.dart';
+import 'package:l_breez/models/payment_minutiae.dart';
+
+class PaymentDetailsDialogRefundTxAmount extends StatelessWidget {
+  final PaymentMinutiae paymentMinutiae;
+  final AutoSizeGroup? labelAutoSizeGroup;
+  final AutoSizeGroup? valueAutoSizeGroup;
+
+  const PaymentDetailsDialogRefundTxAmount({
+    super.key,
+    required this.paymentMinutiae,
+    this.labelAutoSizeGroup,
+    this.valueAutoSizeGroup,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = context.texts();
+    final themeData = Theme.of(context);
+
+    if (paymentMinutiae.refundTxAmountSat == 0) return const SizedBox.shrink();
+
+    return Container(
+      height: 36.0,
+      padding: const EdgeInsets.only(left: 16.0, right: 16.0),
+      child: Row(
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(right: 8.0),
+            child: AutoSizeText(
+              "Refund Tx ${texts.payment_details_dialog_amount_title}",
+              style: themeData.primaryTextTheme.headlineMedium,
+              textAlign: TextAlign.left,
+              maxLines: 1,
+              group: labelAutoSizeGroup,
+            ),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              reverse: true,
+              child: BlocBuilder<CurrencyCubit, CurrencyState>(builder: (context, state) {
+                final amountSats = BitcoinCurrency.fromTickerSymbol(
+                  state.bitcoinTicker,
+                ).format(paymentMinutiae.refundTxAmountSat);
+                return AutoSizeText(
+                  paymentMinutiae.paymentType == PaymentType.receive
+                      ? texts.payment_details_dialog_amount_positive(amountSats)
+                      : texts.payment_details_dialog_amount_negative(amountSats),
+                  style: themeData.primaryTextTheme.displaySmall,
+                  textAlign: TextAlign.right,
+                  maxLines: 1,
+                  group: valueAutoSizeGroup,
+                );
+              }),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_swap_id.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_swap_id.dart
@@ -2,19 +2,19 @@ import 'package:flutter/widgets.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart';
 
-class PaymentDetailsDestinationPubkey extends StatelessWidget {
+class PaymentDetailsSwapId extends StatelessWidget {
   final PaymentMinutiae paymentMinutiae;
 
-  const PaymentDetailsDestinationPubkey({required this.paymentMinutiae, super.key});
+  const PaymentDetailsSwapId({required this.paymentMinutiae, super.key});
 
   @override
   Widget build(BuildContext context) {
-    final destinationPubkey = paymentMinutiae.swapId;
-    return destinationPubkey.isNotEmpty
+    final swapId = paymentMinutiae.swapId;
+    return swapId.isNotEmpty
         ? ShareablePaymentRow(
             // TODO: Move this message to Breez-Translations
             title: "Swap ID",
-            sharedValue: destinationPubkey,
+            sharedValue: swapId,
           )
         : const SizedBox.shrink();
   }

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_tx_id.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_tx_id.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/widgets.dart';
+import 'package:l_breez/models/payment_minutiae.dart';
+import 'package:l_breez/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart';
+import 'package:l_breez/utils/blockchain_explorer_utils.dart';
+
+class PaymentDetailsTxId extends StatelessWidget {
+  final PaymentMinutiae paymentMinutiae;
+
+  const PaymentDetailsTxId({required this.paymentMinutiae, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final txId = paymentMinutiae.txId;
+    return txId.isNotEmpty
+        ? ShareablePaymentRow(
+            // TODO: Move this message to Breez-Translations
+            title: "Transaction ID",
+            sharedValue: txId,
+            isURL: true,
+            urlValue: BlockChainExplorerUtils().formatTransactionUrl(txid: txId),
+          )
+        : const SizedBox.shrink();
+  }
+}

--- a/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
@@ -1,14 +1,15 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
-import 'package:service_injector/service_injector.dart';
 import 'package:l_breez/utils/external_browser.dart';
 import 'package:l_breez/widgets/flushbar.dart';
+import 'package:service_injector/service_injector.dart';
 import 'package:share_plus/share_plus.dart';
 
 class ShareablePaymentRow extends StatelessWidget {
   final String title;
   final String sharedValue;
+  final String? urlValue;
   final bool isURL;
   final bool isExpanded;
   final TextStyle? titleTextStyle;
@@ -23,6 +24,7 @@ class ShareablePaymentRow extends StatelessWidget {
     super.key,
     required this.title,
     required this.sharedValue,
+    this.urlValue,
     this.isURL = false,
     this.isExpanded = false,
     this.titleTextStyle,
@@ -64,8 +66,9 @@ class ShareablePaymentRow extends StatelessWidget {
                 child: Padding(
                   padding: childrenPadding ?? const EdgeInsets.only(left: 16.0, right: 0.0),
                   child: GestureDetector(
-                    onTap:
-                        isURL ? () => launchLinkOnExternalBrowser(context, linkAddress: sharedValue) : null,
+                    onTap: isURL
+                        ? () => launchLinkOnExternalBrowser(context, linkAddress: urlValue ?? sharedValue)
+                        : null,
                     child: Text(
                       sharedValue,
                       textAlign: TextAlign.left,

--- a/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
+++ b/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
@@ -2,11 +2,14 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_amount.dart';
+import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_bolt11.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_content_title.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_date.dart';
-import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_destination_pubkey.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_preimage.dart';
+import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_refund_tx_fee_amount.dart';
+import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_swap_id.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_title.dart';
+import 'package:l_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_tx_id.dart';
 import 'package:logging/logging.dart';
 
 final AutoSizeGroup _labelGroup = AutoSizeGroup();
@@ -36,10 +39,13 @@ class PaymentDetailsDialog extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              PaymentDetailsDialogContentTitle(
-                paymentMinutiae: paymentMinutiae,
-              ),
+              PaymentDetailsDialogContentTitle(paymentMinutiae: paymentMinutiae),
               PaymentDetailsDialogAmount(
+                paymentMinutiae: paymentMinutiae,
+                labelAutoSizeGroup: _labelGroup,
+                valueAutoSizeGroup: _valueGroup,
+              ),
+              PaymentDetailsDialogRefundTxAmount(
                 paymentMinutiae: paymentMinutiae,
                 labelAutoSizeGroup: _labelGroup,
                 valueAutoSizeGroup: _valueGroup,
@@ -49,12 +55,10 @@ class PaymentDetailsDialog extends StatelessWidget {
                 labelAutoSizeGroup: _labelGroup,
                 valueAutoSizeGroup: _valueGroup,
               ),
-              PaymentDetailsPreimage(
-                paymentMinutiae: paymentMinutiae,
-              ),
-              PaymentDetailsDestinationPubkey(
-                paymentMinutiae: paymentMinutiae,
-              ),
+              PaymentDetailsBolt11(paymentMinutiae: paymentMinutiae),
+              PaymentDetailsPreimage(paymentMinutiae: paymentMinutiae),
+              PaymentDetailsTxId(paymentMinutiae: paymentMinutiae),
+              PaymentDetailsSwapId(paymentMinutiae: paymentMinutiae),
             ],
           ),
         ),

--- a/lib/utils/blockchain_explorer_utils.dart
+++ b/lib/utils/blockchain_explorer_utils.dart
@@ -1,10 +1,11 @@
 // TODO: Liquid - This file is unused - Re-add for swap tx's after input parser is implemented
 class BlockChainExplorerUtils {
-  String formatTransactionUrl({required String txid, String mempoolInstance = "https://mempool.space/"}) {
+  String formatTransactionUrl(
+      {required String txid, String mempoolInstance = "https://liquid.fra.mempool.space/"}) {
     return "$mempoolInstance/tx/$txid";
   }
 
-  String formatRecommendedFeesUrl({String mempoolInstance = "https://mempool.space/"}) {
+  String formatRecommendedFeesUrl({String mempoolInstance = "https://liquid.fra.mempool.space/"}) {
     return "$mempoolInstance/api/v1/fees/recommended";
   }
 }

--- a/packages/breez_logger/pubspec.lock
+++ b/packages/breez_logger/pubspec.lock
@@ -283,7 +283,7 @@ packages:
     source: hosted
     version: "1.1.0"
   flutter:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/packages/breez_logger/pubspec.yaml
+++ b/packages/breez_logger/pubspec.yaml
@@ -3,8 +3,12 @@ publish_to: none
 
 environment:
   sdk: '>=3.4.0 <4.0.0'
+  flutter: ">=3.22.0"
 
 dependencies:
+  flutter:
+    sdk: flutter
+
   breez_sdk_liquid:
     path: ../breez_sdk_liquid
   breez_liquid:

--- a/packages/breez_preferences/pubspec.lock
+++ b/packages/breez_preferences/pubspec.lock
@@ -34,7 +34,7 @@ packages:
     source: hosted
     version: "7.0.0"
   flutter:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/packages/breez_preferences/pubspec.yaml
+++ b/packages/breez_preferences/pubspec.yaml
@@ -3,8 +3,12 @@ publish_to: none
 
 environment:
   sdk: '>=3.4.0 <4.0.0'
+  flutter: ">=3.22.0"
 
 dependencies:
+  flutter:
+    sdk: flutter
+
+  logging: ^1.2.0
   shared_preferences: ^2.2.3
   shared_preference_app_group: ^1.1.1 # iOS Notification Service extension requirement to access shared preferences
-  logging: ^1.2.0

--- a/packages/breez_sdk_liquid/pubspec.lock
+++ b/packages/breez_sdk_liquid/pubspec.lock
@@ -283,7 +283,7 @@ packages:
     source: hosted
     version: "1.1.0"
   flutter:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/packages/breez_sdk_liquid/pubspec.yaml
+++ b/packages/breez_sdk_liquid/pubspec.yaml
@@ -3,8 +3,12 @@ publish_to: none
 
 environment:
   sdk: '>=3.4.0 <4.0.0'
+  flutter: ">=3.22.0"
 
 dependencies:
+  flutter:
+    sdk: flutter
+
   app_group_directory: ^2.0.0
   service_injector:
     path: ../service_injector

--- a/packages/device_client/pubspec.lock
+++ b/packages/device_client/pubspec.lock
@@ -82,7 +82,7 @@ packages:
     source: hosted
     version: "1.1.0"
   flutter:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/packages/device_client/pubspec.yaml
+++ b/packages/device_client/pubspec.yaml
@@ -4,7 +4,12 @@ publish_to: none
 environment:
   sdk: '>=3.4.0 <4.0.0'
 
+  flutter: ">=3.22.0"
+
 dependencies:
+  flutter:
+    sdk: flutter
+
   clipboard_watcher: ^0.2.1
   logging: ^1.2.0
   package_info_plus: ^8.0.0

--- a/packages/service_injector/pubspec.lock
+++ b/packages/service_injector/pubspec.lock
@@ -634,7 +634,7 @@ packages:
     source: hosted
     version: "1.1.1"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: d3bbe5553a986e83980916ded2f0b435ef2e1893dfaa29d5a7a790d0eca12180

--- a/packages/service_injector/pubspec.yaml
+++ b/packages/service_injector/pubspec.yaml
@@ -25,5 +25,7 @@ dependencies:
     path: ../breez_sdk_liquid
   credentials_manager:
     path: ../credentials_manager
+
   logging: ^1.2.0
   rxdart: ^0.28.0
+  shared_preferences: ^2.2.3


### PR DESCRIPTION
This PR adds additional `Payment` details to `PaymentMinutiae` and displays them on the PaymentDetailsDialog.

#### Changelist:
- Added `bolt11`, `txId`, `refundTxId` & `refundTxAmountSat` to `PaymentMinutiae`
  - Resolved several other payment titles
- TxID is explorable on `Liquid.mainnet` mempool instance
  - Added `urlValue` to `ShareablePaymentRow` so the displayed value and URL value is different
- Remove unused `integration_test` dependency
- Address `depend_on_referenced_packages` linter warnings