### PR TITLE
Beautify error message when attempting to connect with an invalid mnemonic

### DIFF
--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -76,10 +76,6 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
     emit(state.copyWith(connectionStatus: ConnectionStatus.connecting));
     if (mnemonic != null) {
       await _credentialsManager.storeMnemonic(mnemonic: mnemonic);
-      emit(state.copyWith(
-        initial: false,
-        verificationStatus: isRestore ? VerificationStatus.verified : null,
-      ));
     }
     await _startSdkForever(isRestore: isRestore);
   }
@@ -120,7 +116,11 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
       );
       await _liquidSdk.connect(req: req);
       _log.info("connected to breez lib");
-      emit(state.copyWith(connectionStatus: ConnectionStatus.connected));
+      emit(state.copyWith(
+        initial: false,
+        connectionStatus: ConnectionStatus.connected,
+        verificationStatus: isRestore ? VerificationStatus.verified : null,
+      ));
       _watchAccountChanges().listen((acc) {
         _log.info("State changed: $acc");
         emit(acc);

--- a/lib/routes/chainswap/send/send_chainswap_confirmation_page.dart
+++ b/lib/routes/chainswap/send/send_chainswap_confirmation_page.dart
@@ -1,7 +1,7 @@
-import 'package:breez_liquid/breez_liquid.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/chainswap/send/fee/fee_breakdown/fee_breakdown.dart';
 import 'package:l_breez/routes/chainswap/send/fee/fee_option.dart';

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -1,4 +1,5 @@
 import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import "package:flutter_rust_bridge/flutter_rust_bridge.dart";
 import 'package:logging/logging.dart';
 
@@ -17,6 +18,12 @@ String extractExceptionMessage(
       message = _localizedExceptionMessage(texts, message);
       return message;
     }
+  }
+  if (exception is SdkError_Generic) {
+    var message = exception.err.replaceAll("\n", " ").trim();
+    message = _extractInnerErrorMessage(message)?.trim() ?? message;
+    message = _localizedExceptionMessage(texts, message);
+    return message;
   }
   return _extractInnerErrorMessage(exception.toString()) ?? defaultErrorMsg ?? exception.toString();
 }
@@ -58,7 +65,7 @@ String _localizedExceptionMessage(
     return texts.lsp_error_cannot_open_channel;
   } else if (messageToLower.contains("dns error") || messageToLower.contains("os error 104")) {
     return texts.generic_network_error;
-  } else if (messageToLower.contains("Recovery failed:")) {
+  } else if (messageToLower.contains("mnemonic has an invalid checksum")) {
     return texts.enter_backup_phrase_error;
   } else {
     return originalMessage;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -111,7 +111,7 @@ packages:
       path: "../breez-sdk-liquid/packages/dart"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.3-rc1"
   breez_logger:
     dependency: "direct main"
     description:
@@ -606,7 +606,7 @@ packages:
       path: "../breez-sdk-liquid/packages/flutter"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.3-rc1"
   flutter_fgbg:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Fixes #56


Only handles the case for when "mnemonic has an invalid checksum" error message is returned from `connect`.

It's advised to return a specific, identifiable `SdkError` for this case from the Liquid SDK.

### Other changelist:
- Do not update account state until wallet is connected
  - This caused an issue where the wallet would attempt to restore with the invalid mnemonic stored on the device on next startup.