### PR TITLE
Move route names to routes themselves

### DIFF
--- a/lib/app/routes/routes.dart
+++ b/lib/app/routes/routes.dart
@@ -28,87 +28,87 @@ Route? onGenerateRoute({
 }) {
   _log.info("New route: ${settings.name}");
   switch (settings.name) {
-    case '/intro':
+    case InitialWalkthroughPage.routeName:
       return FadeInRoute(
         builder: (_) => const InitialWalkthroughPage(),
         settings: settings,
       );
-    case 'splash':
+    case SplashPage.routeName:
       return FadeInRoute(
         builder: (_) => SplashPage(isInitial: accountState.initial),
         settings: settings,
       );
-    case 'lockscreen':
+    case LockScreen.routeName:
       return NoTransitionRoute(
         builder: (_) => const LockScreen(
           authorizedAction: AuthorizedAction.launchHome,
         ),
         settings: settings,
       );
-    case '/enter_mnemonics':
+    case EnterMnemonicsPage.routeName:
       return FadeInRoute<String>(
         builder: (_) => EnterMnemonicsPage(
           initialWords: settings.arguments as List<String>? ?? [],
         ),
         settings: settings,
       );
-    case '/':
+    case Home.routeName:
       return FadeInRoute(
         builder: (_) => NavigatorPopHandler(
           onPop: () => homeNavigatorKey.currentState!.maybePop(),
           child: Navigator(
-            initialRoute: "/",
+            initialRoute: Home.routeName,
             key: homeNavigatorKey,
             onGenerateRoute: (RouteSettings settings) {
               _log.info("New inner route: ${settings.name}");
               switch (settings.name) {
-                case '/':
+                case Home.routeName:
                   return FadeInRoute(
                     builder: (_) => const Home(),
                     settings: settings,
                   );
-                case '/create_invoice':
+                case CreateInvoicePage.routeName:
                   return FadeInRoute(
                     builder: (_) => const CreateInvoicePage(),
                     settings: settings,
                   );
-                case '/receive_chainswap':
+                case ReceiveChainSwapPage.routeName:
                   return FadeInRoute(
                     builder: (_) => const ReceiveChainSwapPage(),
                     settings: settings,
                   );
-                case '/send_chainswap':
+                case SendChainSwapPage.routeName:
                   return FadeInRoute(
                     builder: (_) => SendChainSwapPage(
                       btcAddressData: settings.arguments as BitcoinAddressData?,
                     ),
                     settings: settings,
                   );
-                case '/fiat_currency':
+                case FiatCurrencySettings.routeName:
                   return FadeInRoute(
                     builder: (_) => const FiatCurrencySettings(),
                     settings: settings,
                   );
-                case '/security':
+                case SecurityPage.routeName:
                   return FadeInRoute(
                     builder: (_) => const SecuredPage(
                       securedWidget: SecurityPage(),
                     ),
                     settings: settings,
                   );
-                case '/mnemonics':
+                case MnemonicsConfirmationPage.routeName:
                   return FadeInRoute(
                     builder: (_) => MnemonicsConfirmationPage(
                       mnemonics: settings.arguments as String,
                     ),
                     settings: settings,
                   );
-                case '/developers':
+                case DevelopersView.routeName:
                   return FadeInRoute(
                     builder: (_) => const DevelopersView(),
                     settings: settings,
                   );
-                case '/qr_scan':
+                case QRScan.routeName:
                   return MaterialPageRoute<String>(
                     fullscreenDialog: true,
                     builder: (_) => const QRScan(),

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -5,6 +5,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/app/app_theme_manager/app_theme_manager.dart';
 import 'package:l_breez/app/routes/routes.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/routes/security/lock_screen.dart';
+import 'package:l_breez/routes/splash/splash_page.dart';
 import 'package:service_injector/service_injector.dart';
 import 'package:theme_provider/theme_provider.dart';
 
@@ -82,7 +84,8 @@ class _AppViewState extends State<AppView> {
                 child: child!,
               );
             },
-            initialRoute: securityState.pinStatus == PinStatus.enabled ? "lockscreen" : "splash",
+            initialRoute:
+                securityState.pinStatus == PinStatus.enabled ? LockScreen.routeName : SplashPage.routeName,
             onGenerateRoute: (RouteSettings settings) => onGenerateRoute(
               settings: settings,
               homeNavigatorKey: _homeNavigatorKey,

--- a/lib/handlers/input_handler/src/input_handler.dart
+++ b/lib/handlers/input_handler/src/input_handler.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/handlers/handler/handler.dart';
 import 'package:l_breez/models/invoice.dart';
+import 'package:l_breez/routes/chainswap/send/send_chainswap_page.dart';
 import 'package:l_breez/routes/lnurl/auth/lnurl_auth_handler.dart';
 import 'package:l_breez/routes/lnurl/payment/lnurl_payment_handler.dart';
 import 'package:l_breez/routes/lnurl/withdraw/lnurl_withdraw_handler.dart';
@@ -114,7 +115,7 @@ class InputHandler extends Handler {
   Future handleBitcoinAddress(BuildContext context, BitcoinAddressInputState inputState) async {
     _log.fine("handle bitcoin address $inputState");
     if (inputState.source == InputSource.qrcodeReader) {
-      return await Navigator.of(context).pushNamed("/reverse_swap", arguments: inputState.data);
+      return await Navigator.of(context).pushNamed(SendChainSwapPage.routeName, arguments: inputState.data);
     }
   }
 

--- a/lib/routes/chainswap/receive/receive_chainswap_page.dart
+++ b/lib/routes/chainswap/receive/receive_chainswap_page.dart
@@ -18,6 +18,8 @@ import 'package:l_breez/widgets/single_button_bottom_bar.dart';
 import 'package:l_breez/widgets/transparent_page_route.dart';
 
 class ReceiveChainSwapPage extends StatefulWidget {
+  static const routeName = "/receive_chainswap";
+
   const ReceiveChainSwapPage({super.key});
 
   @override

--- a/lib/routes/chainswap/send/send_chainswap_button.dart
+++ b/lib/routes/chainswap/send/send_chainswap_button.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/routes/home/home_page.dart';
 import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/widgets/error_dialog.dart';
 import 'package:l_breez/widgets/loader.dart';
@@ -39,7 +40,7 @@ class SendChainSwapButton extends StatelessWidget {
     try {
       final req = PayOnchainRequest(address: recipientAddress, prepareRes: preparePayOnchainResponse);
       await chainSwapCubit.payOnchain(req: req);
-      navigator.pushNamedAndRemoveUntil("/", (Route<dynamic> route) => false);
+      navigator.pushNamedAndRemoveUntil(Home.routeName, (Route<dynamic> route) => false);
     } catch (e) {
       navigator.pop(loaderRoute);
       if (!context.mounted) return;

--- a/lib/routes/chainswap/send/send_chainswap_page.dart
+++ b/lib/routes/chainswap/send/send_chainswap_page.dart
@@ -11,6 +11,8 @@ import 'package:l_breez/widgets/loader.dart';
 class SendChainSwapPage extends StatefulWidget {
   final BitcoinAddressData? btcAddressData;
 
+  static const routeName = "/send_chainswap";
+
   const SendChainSwapPage({super.key, required this.btcAddressData});
 
   @override

--- a/lib/routes/chainswap/send/widgets/bitcoin_address_text_form_field.dart
+++ b/lib/routes/chainswap/send/widgets/bitcoin_address_text_form_field.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/models/bitcoin_address_info.dart';
 import 'package:l_breez/routes/chainswap/send/validator_holder.dart';
+import 'package:l_breez/routes/qr_scan/qr_scan.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/flushbar.dart';
 import 'package:logging/logging.dart';
@@ -29,7 +30,7 @@ class BitcoinAddressTextFormField extends TextFormField {
               ),
               tooltip: context.texts().withdraw_funds_scan_barcode,
               onPressed: () async {
-                Navigator.pushNamed<String>(context, "/qr_scan").then(
+                Navigator.pushNamed<String>(context, QRScan.routeName).then(
                   (barcode) {
                     _log.info("Scanned string: '$barcode'");
                     final address = BitcoinAddressInfo.fromScannedString(barcode).address;

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -25,6 +25,8 @@ class CreateInvoicePage extends StatefulWidget {
   final Function(LNURLPageResult? result)? onFinish;
   final LnUrlWithdrawRequestData? requestData;
 
+  static const routeName = "/create_invoice";
+
   const CreateInvoicePage({super.key, this.onFinish, this.requestData})
       : assert(
           requestData == null || (onFinish != null),

--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -34,6 +34,8 @@ class Choice {
 class DevelopersView extends StatefulWidget {
   const DevelopersView({super.key});
 
+  static const routeName = "/developers";
+
   @override
   State<DevelopersView> createState() => _DevelopersViewState();
 }

--- a/lib/routes/fiat_currencies/fiat_currency_settings.dart
+++ b/lib/routes/fiat_currencies/fiat_currency_settings.dart
@@ -13,6 +13,8 @@ import 'package:l_breez/widgets/loader.dart';
 const double itemHeight = 72.0;
 
 class FiatCurrencySettings extends StatefulWidget {
+  static const routeName = "/fiat_currency";
+
   const FiatCurrencySettings({super.key});
 
   @override

--- a/lib/routes/home/home_page.dart
+++ b/lib/routes/home/home_page.dart
@@ -16,6 +16,8 @@ import 'package:l_breez/routes/security/auto_lock_mixin.dart';
 import 'package:l_breez/widgets/error_dialog.dart';
 
 class Home extends StatefulWidget {
+  static const routeName = "/";
+
   const Home({super.key});
 
   @override

--- a/lib/routes/home/widgets/app_bar/account_required_actions.dart
+++ b/lib/routes/home/widgets/app_bar/account_required_actions.dart
@@ -4,6 +4,7 @@ import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/home/widgets/app_bar/warning_action.dart';
 import 'package:l_breez/routes/home/widgets/enable_backup_dialog.dart';
 import 'package:l_breez/routes/home/widgets/rotator.dart';
+import 'package:l_breez/routes/initial_walkthrough/mnemonics/mnemonics_confirmation_page.dart';
 import 'package:l_breez/widgets/backup_in_progress_dialog.dart';
 import 'package:logging/logging.dart';
 import 'package:service_injector/service_injector.dart';
@@ -29,7 +30,7 @@ class AccountRequiredActionsIndicator extends StatelessWidget {
                 await ServiceInjector().keychain.read(CredentialsManager.accountMnemonic).then(
                       (accountMnemonic) => Navigator.pushNamed(
                         context,
-                        '/mnemonics',
+                        MnemonicsConfirmationPage.routeName,
                         arguments: accountMnemonic,
                       ),
                     );

--- a/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/routes/qr_scan/qr_scan.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/flushbar.dart';
 import 'package:l_breez/widgets/loader.dart';
@@ -182,7 +183,7 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
     final texts = context.texts();
 
     FocusScope.of(context).requestFocus(FocusNode());
-    String? barcode = await Navigator.pushNamed<String>(context, "/qr_scan");
+    String? barcode = await Navigator.pushNamed<String>(context, QRScan.routeName);
     if (barcode == null) {
       return;
     }

--- a/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
@@ -1,5 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
+import 'package:l_breez/routes/chainswap/receive/receive_chainswap_page.dart';
+import 'package:l_breez/routes/create_invoice/create_invoice_page.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 
 import 'bottom_action_item_image.dart';
@@ -28,7 +30,7 @@ class ReceiveOptionsBottomSheet extends StatelessWidget {
           onTap: () {
             final navigatorState = Navigator.of(context);
             navigatorState.pop();
-            navigatorState.pushNamed("/create_invoice");
+            navigatorState.pushNamed(CreateInvoicePage.routeName);
           },
         ),
         const SizedBox(height: 8.0),
@@ -43,7 +45,7 @@ class ReceiveOptionsBottomSheet extends StatelessWidget {
           onTap: () {
             final navigatorState = Navigator.of(context);
             navigatorState.pop();
-            navigatorState.pushNamed("/receive_chainswap");
+            navigatorState.pushNamed(ReceiveChainSwapPage.routeName);
           },
         ),
       ],

--- a/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
+import 'package:l_breez/routes/chainswap/send/send_chainswap_page.dart';
 import 'package:l_breez/routes/home/widgets/bottom_actions_bar/bottom_action_item_image.dart';
 import 'package:l_breez/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
@@ -44,7 +45,7 @@ class _SendOptionsBottomSheetState extends State<SendOptionsBottomSheet> {
           onTap: () {
             final navigatorState = Navigator.of(context);
             navigatorState.pop();
-            navigatorState.pushNamed("/send_chainswap");
+            navigatorState.pushNamed(SendChainSwapPage.routeName);
           },
         ),
       ],

--- a/lib/routes/home/widgets/drawer/home_drawer.dart
+++ b/lib/routes/home/widgets/drawer/home_drawer.dart
@@ -3,7 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/user_profile.dart';
+import 'package:l_breez/routes/dev/developers_view.dart';
+import 'package:l_breez/routes/fiat_currencies/fiat_currency_settings.dart';
 import 'package:l_breez/routes/home/widgets/drawer/breez_navigation_drawer.dart';
+import 'package:l_breez/routes/security/security_page.dart';
 import 'package:l_breez/widgets/flushbar.dart';
 
 class HomeDrawer extends StatefulWidget {
@@ -84,12 +87,12 @@ class HomeDrawerState extends State<HomeDrawer> {
 
     return [
       DrawerItemConfig(
-        "/fiat_currency",
+        FiatCurrencySettings.routeName,
         texts.home_drawer_item_title_fiat_currencies,
         "src/icon/fiat_currencies.png",
       ),
       DrawerItemConfig(
-        "/security",
+        SecurityPage.routeName,
         texts.home_drawer_item_title_security_and_backup,
         "src/icon/security.png",
       ),
@@ -102,7 +105,7 @@ class HomeDrawerState extends State<HomeDrawer> {
 
     return [
       DrawerItemConfig(
-        "/developers",
+        DevelopersView.routeName,
         texts.home_drawer_item_title_developers,
         "src/icon/developers.png",
       ),

--- a/lib/routes/home/widgets/qr_action_button.dart
+++ b/lib/routes/home/widgets/qr_action_button.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/routes/qr_scan/qr_scan.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/flushbar.dart';
 import 'package:logging/logging.dart';
@@ -39,7 +40,7 @@ class QrActionButton extends StatelessWidget {
     InputCubit inputCubit = context.read<InputCubit>();
 
     _log.info("Start qr code scan");
-    Navigator.pushNamed<String>(context, "/qr_scan").then(
+    Navigator.pushNamed<String>(context, QRScan.routeName).then(
       (barcode) {
         _log.info("Scanned string: '$barcode'");
         if (barcode == null) return;

--- a/lib/routes/initial_walkthrough/initial_walkthrough.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/initial_walkthrough/beta_warning_dialog.dart';
+import 'package:l_breez/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/theme/theme_provider.dart';
 import 'package:l_breez/utils/exceptions.dart';
@@ -15,6 +16,8 @@ import 'package:logging/logging.dart';
 import 'package:theme_provider/theme_provider.dart';
 
 class InitialWalkthroughPage extends StatefulWidget {
+  static const routeName = "/intro";
+
   const InitialWalkthroughPage({super.key});
 
   @override
@@ -208,7 +211,7 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
   }) async {
     _log.info("Get mnemonic, initialWords: ${initialWords?.length}");
     return await Navigator.of(context).pushNamed<String>(
-      "/enter_mnemonics",
+      EnterMnemonicsPage.routeName,
       arguments: initialWords,
     );
   }

--- a/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
@@ -6,6 +6,8 @@ import 'package:l_breez/widgets/back_button.dart' as back_button;
 class EnterMnemonicsPage extends StatefulWidget {
   final List<String> initialWords;
 
+  static const routeName = "/enter_mnemonics";
+
   const EnterMnemonicsPage({super.key, required this.initialWords});
 
   @override

--- a/lib/routes/initial_walkthrough/mnemonics/mnemonics_confirmation_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/mnemonics_confirmation_page.dart
@@ -10,6 +10,8 @@ import 'package:l_breez/widgets/single_button_bottom_bar.dart';
 class MnemonicsConfirmationPage extends StatefulWidget {
   final String mnemonics;
 
+  static const routeName = "/mnemonics";
+
   const MnemonicsConfirmationPage({super.key, required this.mnemonics});
 
   @override

--- a/lib/routes/initial_walkthrough/mnemonics/verify_mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/verify_mnemonics_page.dart
@@ -4,6 +4,8 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/routes/home/home_page.dart';
+import 'package:l_breez/routes/security/security_page.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/widgets/back_button.dart' as back_button;
 import 'package:l_breez/widgets/single_button_bottom_bar.dart';
@@ -107,7 +109,8 @@ class VerifyMnemonicsPageState extends State<VerifyMnemonicsPage> {
                       // Pop to where the verification flow has started from,
                       // which is either from "Verify Backup Phrase" option on Security page
                       // or through WarningAction on Home page.
-                      if (route.settings.name == "/security" || route.settings.name == "/") {
+                      if (route.settings.name == SecurityPage.routeName ||
+                          route.settings.name == Home.routeName) {
                         shouldPop = true;
                       }
                       return shouldPop;

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -1,13 +1,14 @@
 import 'dart:async';
 
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/routes/create_invoice/create_invoice_page.dart';
 import 'package:l_breez/routes/create_invoice/widgets/successful_payment.dart';
+import 'package:l_breez/routes/home/home_page.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:l_breez/widgets/error_dialog.dart';
 import 'package:l_breez/widgets/transparent_page_route.dart';
-import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger("HandleLNURLWithdrawPageResult");
@@ -23,7 +24,7 @@ Future<LNURLPageResult?> handleWithdrawRequest(
         requestData: requestData,
         onFinish: (LNURLPageResult? response) {
           completer.complete(response);
-          Navigator.of(context).popUntil((route) => route.settings.name == "/");
+          Navigator.of(context).popUntil((route) => route.settings.name == Home.routeName);
         },
       ),
     ),

--- a/lib/routes/qr_scan/qr_scan.dart
+++ b/lib/routes/qr_scan/qr_scan.dart
@@ -14,6 +14,8 @@ final _log = Logger("QRScan");
 class QRScan extends StatefulWidget {
   const QRScan({super.key});
 
+  static const routeName = "/qr_scan";
+
   @override
   State<StatefulWidget> createState() => QRScanState();
 }

--- a/lib/routes/security/lock_screen.dart
+++ b/lib/routes/security/lock_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/routes/home/home_page.dart';
 import 'package:l_breez/routes/security/widget/pin_code_widget.dart';
 import 'package:l_breez/theme/breez_light_theme.dart';
 import 'package:l_breez/widgets/route.dart';
@@ -13,6 +14,8 @@ import 'package:path_provider/path_provider.dart';
 
 class LockScreen extends StatelessWidget {
   final AuthorizedAction authorizedAction;
+
+  static const routeName = "lockscreen";
 
   const LockScreen({super.key, required this.authorizedAction});
 
@@ -75,7 +78,7 @@ class LockScreen extends StatelessWidget {
   void _authorized(NavigatorState navigator) {
     switch (authorizedAction) {
       case AuthorizedAction.launchHome:
-        navigator.pushReplacementNamed("/");
+        navigator.pushReplacementNamed(Home.routeName);
         break;
       case AuthorizedAction.popPage:
         navigator.pop(true);

--- a/lib/routes/security/security_page.dart
+++ b/lib/routes/security/security_page.dart
@@ -6,6 +6,8 @@ import 'package:l_breez/theme/breez_light_theme.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
 
 class SecurityPage extends StatelessWidget {
+  static const routeName = "/security";
+
   const SecurityPage({super.key});
 
   @override

--- a/lib/routes/security/widget/mnemonics/security_mnemonics_management.dart
+++ b/lib/routes/security/widget/mnemonics/security_mnemonics_management.dart
@@ -3,6 +3,7 @@ import 'package:credentials_manager/credentials_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/routes/initial_walkthrough/mnemonics/mnemonics_confirmation_page.dart';
 import 'package:l_breez/routes/initial_walkthrough/mnemonics/mnemonics_page.dart';
 import 'package:l_breez/widgets/route.dart';
 import 'package:service_injector/service_injector.dart';
@@ -40,7 +41,7 @@ class SecurityMnemonicsManagement extends StatelessWidget {
                 if (account.verificationStatus == VerificationStatus.unverified) {
                   Navigator.pushNamed(
                     context,
-                    '/mnemonics',
+                    MnemonicsConfirmationPage.routeName,
                     arguments: accountMnemonic,
                   );
                 } else {

--- a/lib/routes/splash/splash_page.dart
+++ b/lib/routes/splash/splash_page.dart
@@ -2,11 +2,15 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:l_breez/routes/home/home_page.dart';
+import 'package:l_breez/routes/initial_walkthrough/initial_walkthrough.dart';
 import 'package:l_breez/routes/splash/splash_animation_widget.dart';
 import 'package:l_breez/theme/theme_provider.dart';
 
 class SplashPage extends StatefulWidget {
   final bool isInitial;
+
+  static const routeName = "splash";
 
   const SplashPage({super.key, required this.isInitial});
 
@@ -20,11 +24,11 @@ class SplashPageState extends State<SplashPage> {
     super.initState();
     if (widget.isInitial) {
       Timer(const Duration(milliseconds: 3600), () {
-        Navigator.of(context).pushReplacementNamed('/intro');
+        Navigator.of(context).pushReplacementNamed(InitialWalkthroughPage.routeName);
       });
     } else {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        Navigator.of(context).pushReplacementNamed('/');
+        Navigator.of(context).pushReplacementNamed(Home.routeName);
       });
     }
   }


### PR DESCRIPTION
Fixes #58

This issue was caused by `InputHandler` using an incorrect route name, `"/reverse_swap"`.

All route names are moved to routes themselves and referenced directly to avoid such mistakes in the future caused by renaming.