### PR TITLE
Do not display payments that fall below Liquid network minimum payment limit of 1,000 sats

### DIFF
--- a/lib/app/routes/routes.dart
+++ b/lib/app/routes/routes.dart
@@ -26,7 +26,6 @@ Route? onGenerateRoute({
   required RouteSettings settings,
   required GlobalKey<NavigatorState> homeNavigatorKey,
   required accountState,
-  required SecurityState securityState,
 }) {
   _log.info("New route: ${settings.name}");
   final paymentLimitsCubit = PaymentLimitsCubit(ServiceInjector().liquidSDK);

--- a/lib/app/routes/routes.dart
+++ b/lib/app/routes/routes.dart
@@ -28,8 +28,6 @@ Route? onGenerateRoute({
   required accountState,
 }) {
   _log.info("New route: ${settings.name}");
-  final paymentLimitsCubit = PaymentLimitsCubit(ServiceInjector().liquidSDK);
-
   switch (settings.name) {
     case InitialWalkthroughPage.routeName:
       return FadeInRoute(
@@ -73,7 +71,7 @@ Route? onGenerateRoute({
                 case CreateInvoicePage.routeName:
                   return FadeInRoute(
                     builder: (_) => BlocProvider(
-                      create: (BuildContext context) => paymentLimitsCubit,
+                      create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().liquidSDK),
                       child: const CreateInvoicePage(),
                     ),
                     settings: settings,
@@ -81,7 +79,7 @@ Route? onGenerateRoute({
                 case ReceiveChainSwapPage.routeName:
                   return FadeInRoute(
                     builder: (_) => BlocProvider(
-                      create: (BuildContext context) => paymentLimitsCubit,
+                      create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().liquidSDK),
                       child: const ReceiveChainSwapPage(),
                     ),
                     settings: settings,
@@ -89,7 +87,7 @@ Route? onGenerateRoute({
                 case SendChainSwapPage.routeName:
                   return FadeInRoute(
                     builder: (_) => BlocProvider(
-                      create: (BuildContext context) => paymentLimitsCubit,
+                      create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().liquidSDK),
                       child: SendChainSwapPage(
                         btcAddressData: settings.arguments as BitcoinAddressData?,
                       ),

--- a/lib/app/routes/routes.dart
+++ b/lib/app/routes/routes.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/chainswap/receive/receive_chainswap_page.dart';
@@ -17,6 +18,7 @@ import 'package:l_breez/routes/security/security_page.dart';
 import 'package:l_breez/routes/splash/splash_page.dart';
 import 'package:l_breez/widgets/route.dart';
 import 'package:logging/logging.dart';
+import 'package:service_injector/service_injector.dart';
 
 final _log = Logger("Routes");
 
@@ -27,6 +29,8 @@ Route? onGenerateRoute({
   required SecurityState securityState,
 }) {
   _log.info("New route: ${settings.name}");
+  final paymentLimitsCubit = PaymentLimitsCubit(ServiceInjector().liquidSDK);
+
   switch (settings.name) {
     case InitialWalkthroughPage.routeName:
       return FadeInRoute(
@@ -69,18 +73,27 @@ Route? onGenerateRoute({
                   );
                 case CreateInvoicePage.routeName:
                   return FadeInRoute(
-                    builder: (_) => const CreateInvoicePage(),
+                    builder: (_) => BlocProvider(
+                      create: (BuildContext context) => paymentLimitsCubit,
+                      child: const CreateInvoicePage(),
+                    ),
                     settings: settings,
                   );
                 case ReceiveChainSwapPage.routeName:
                   return FadeInRoute(
-                    builder: (_) => const ReceiveChainSwapPage(),
+                    builder: (_) => BlocProvider(
+                      create: (BuildContext context) => paymentLimitsCubit,
+                      child: const ReceiveChainSwapPage(),
+                    ),
                     settings: settings,
                   );
                 case SendChainSwapPage.routeName:
                   return FadeInRoute(
-                    builder: (_) => SendChainSwapPage(
-                      btcAddressData: settings.arguments as BitcoinAddressData?,
+                    builder: (_) => BlocProvider(
+                      create: (BuildContext context) => paymentLimitsCubit,
+                      child: SendChainSwapPage(
+                        btcAddressData: settings.arguments as BitcoinAddressData?,
+                      ),
                     ),
                     settings: settings,
                   );

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -90,7 +90,6 @@ class _AppViewState extends State<AppView> {
               settings: settings,
               homeNavigatorKey: _homeNavigatorKey,
               accountState: accountState,
-              securityState: securityState,
             ),
           );
         },

--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -196,10 +196,8 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
   void validatePayment(int amount, bool outgoing) {
     _log.info("validatePayment: $amount, $outgoing");
     var accState = state;
-    if (outgoing) {
-      if (amount > accState.balance) {
-        throw const InsufficientLocalBalanceError();
-      }
+    if (outgoing && amount > accState.balance) {
+      throw const InsufficientLocalBalanceError();
     }
 
     if (amount > accState.maxPaymentAmountSat) {

--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -19,7 +19,6 @@ import 'package:rxdart/rxdart.dart';
 export 'account_state.dart';
 export 'account_state_assembler.dart';
 
-const maxPaymentAmount = 4294967;
 const nodeSyncInterval = 60;
 
 final _log = Logger("AccountCubit");
@@ -193,38 +192,19 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
 
   // validatePayment is used to validate that outgoing/incoming payments meet the liquidity
   // constraints.
-  void validatePayment(
-    int amount,
-    bool outgoing,
-  ) {
+  void validatePayment(int amount, bool outgoing) {
     _log.info("validatePayment: $amount, $outgoing");
-    /*
     var accState = state;
-    if (amount > accState.maxPaymentAmount) {
-      _log.info("Amount $amount is bigger than maxPaymentAmount ${accState.maxPaymentAmount}");
-      throw PaymentExceededLimitError(accState.maxPaymentAmount);
-    }
-
-    if (!outgoing) {
-      if (accState.maxInboundLiquidity == 0) {
-        throw NoChannelCreationZeroLiqudityError();
-      } else if (accState.maxInboundLiquidity < amount) {
-        throw PaymentExcededLiqudityChannelCreationNotPossibleError(accState.maxInboundLiquidity);
-      } else if (amount > accState.maxInboundLiquidity) {
-        throw PaymentExceedLiquidityError(accState.maxInboundLiquidity);
-      } else if (amount > accState.maxAllowedToReceive) {
-        throw PaymentExceededLimitError(accState.maxAllowedToReceive);
+    if (outgoing) {
+      if (amount > accState.balance) {
+        throw const InsufficientLocalBalanceError();
       }
     }
 
-    if (outgoing && amount > accState.maxAllowedToPay) {
-      _log.info("Outgoing but amount $amount is bigger than ${accState.maxAllowedToPay}");
-      if (accState.reserveAmount > 0) {
-        _log.info("Reserve amount ${accState.reserveAmount}");
-        throw PaymentBelowReserveError(accState.reserveAmount);
-      }
-      throw const InsufficientLocalBalanceError();
-    }*/
+    if (amount > accState.maxPaymentAmountSat) {
+      _log.info("Amount $amount is bigger than maxPaymentAmount ${accState.maxPaymentAmountSat}");
+      throw PaymentExceededLimitError(accState.maxPaymentAmountSat);
+    }
   }
 
   void changePaymentFilter({

--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -192,6 +192,7 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
 
   // validatePayment is used to validate that outgoing/incoming payments meet the liquidity
   // constraints.
+  // TODO: NOT USED - Validate liquidity constraints & payment limits in the same place
   void validatePayment(int amount, bool outgoing) {
     _log.info("validatePayment: $amount, $outgoing");
     var accState = state;

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -20,7 +20,7 @@ class AccountState {
   final int walletBalance;
   final int maxAllowedToPay;
   final int maxAllowedToReceive;
-  final int maxPaymentAmount;
+  final int maxPaymentAmountSat;
   final int maxChanReserve;
   final List<String> connectedPeers;
   final int maxInboundLiquidity;
@@ -40,7 +40,7 @@ class AccountState {
     required this.walletBalance,
     required this.maxAllowedToPay,
     required this.maxAllowedToReceive,
-    required this.maxPaymentAmount,
+    required this.maxPaymentAmountSat,
     required this.maxChanReserve,
     required this.connectedPeers,
     required this.maxInboundLiquidity,
@@ -58,7 +58,7 @@ class AccountState {
           blockheight: 0,
           maxAllowedToPay: 0,
           maxAllowedToReceive: 0,
-          maxPaymentAmount: 0,
+          maxPaymentAmountSat: 0,
           maxChanReserve: 0,
           connectedPeers: List.empty(),
           maxInboundLiquidity: 0,
@@ -83,7 +83,7 @@ class AccountState {
     int? walletBalance,
     int? maxAllowedToPay,
     int? maxAllowedToReceive,
-    int? maxPaymentAmount,
+    int? maxPaymentAmountSat,
     int? maxChanReserve,
     List<String>? connectedPeers,
     int? maxInboundLiquidity,
@@ -102,7 +102,7 @@ class AccountState {
       walletBalance: walletBalance ?? this.walletBalance,
       maxAllowedToPay: maxAllowedToPay ?? this.maxAllowedToPay,
       maxAllowedToReceive: maxAllowedToReceive ?? this.maxAllowedToReceive,
-      maxPaymentAmount: maxPaymentAmount ?? this.maxPaymentAmount,
+      maxPaymentAmountSat: maxPaymentAmountSat ?? this.maxPaymentAmountSat,
       blockheight: blockheight ?? this.blockheight,
       maxChanReserve: maxChanReserve ?? this.maxChanReserve,
       connectedPeers: connectedPeers ?? this.connectedPeers,
@@ -131,7 +131,7 @@ class AccountState {
       "walletBalance": walletBalance,
       "maxAllowedToPay": maxAllowedToPay,
       "maxAllowedToReceive": maxAllowedToReceive,
-      "maxPaymentAmount": maxPaymentAmount,
+      "maxPaymentAmount": maxPaymentAmountSat,
       "maxChanReserve": maxChanReserve,
       "maxInboundLiquidity": maxInboundLiquidity,
       "onChainFeeRate": onChainFeeRate,
@@ -153,7 +153,7 @@ class AccountState {
       walletBalance: json["walletBalance"],
       maxAllowedToPay: json["maxAllowedToPay"],
       maxAllowedToReceive: json["maxAllowedToReceive"],
-      maxPaymentAmount: json["maxPaymentAmount"],
+      maxPaymentAmountSat: json["maxPaymentAmount"],
       maxChanReserve: json["maxChanReserve"],
       connectedPeers: <String>[],
       maxInboundLiquidity: json["maxInboundLiquidity"] ?? 0,

--- a/lib/cubit/account/account_state_assembler.dart
+++ b/lib/cubit/account/account_state_assembler.dart
@@ -3,6 +3,7 @@ import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/account/account_cubit.dart';
 import 'package:l_breez/cubit/model/src/payment/payment_filters.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
+import 'package:l_breez/utils/constants.dart';
 
 // assembleAccountState assembles the account state using the local synchronized data.
 AccountState? assembleAccountState(
@@ -23,7 +24,7 @@ AccountState? assembleAccountState(
     balance: walletInfo.balanceSat.toInt(),
     pendingReceive: walletInfo.pendingReceiveSat.toInt(),
     pendingSend: walletInfo.pendingSendSat.toInt(),
-    maxPaymentAmount: maxPaymentAmount,
+    maxPaymentAmountSat: maxPaymentAmountSat,
     onChainFeeRate: 0,
     payments: payments?.map((e) => PaymentMinutiae.fromPayment(e, texts)).toList(),
     paymentFilters: paymentFilters,

--- a/lib/cubit/chain_swap/chain_swap_cubit.dart
+++ b/lib/cubit/chain_swap/chain_swap_cubit.dart
@@ -114,7 +114,7 @@ class ChainSwapCubit extends Cubit<ChainSwapState> {
     OnchainPaymentLimitsResponse onchainLimits,
     int balance,
   ) {
-    if (amount.toInt() > balance) {
+    if (outgoing && amount.toInt() > balance) {
       throw const InsufficientLocalBalanceError();
     }
     var limits = outgoing ? onchainLimits.send : onchainLimits.receive;

--- a/lib/cubit/chain_swap/chain_swap_cubit.dart
+++ b/lib/cubit/chain_swap/chain_swap_cubit.dart
@@ -115,10 +115,10 @@ class ChainSwapCubit extends Cubit<ChainSwapState> {
   ) {
     var limits = outgoing ? onchainLimits.send : onchainLimits.receive;
     if (amount > limits.maxSat) {
-      throw PaymentExceededLimitError(limits.maxSat);
+      throw PaymentExceededLimitError(limits.maxSat.toInt());
     }
     if (amount < limits.minSat) {
-      throw PaymentBelowLimitError(limits.minSat);
+      throw PaymentBelowLimitError(limits.minSat.toInt());
     }
   }
 }

--- a/lib/cubit/chain_swap/chain_swap_cubit.dart
+++ b/lib/cubit/chain_swap/chain_swap_cubit.dart
@@ -16,10 +16,6 @@ class ChainSwapCubit extends Cubit<ChainSwapState> {
 
   ChainSwapCubit(this._liquidSdk) : super(ChainSwapState.initial());
 
-  Future<OnchainPaymentLimitsResponse> fetchOnchainLimits() async {
-    return await _liquidSdk.instance!.fetchOnchainLimits();
-  }
-
   Future<RecommendedFees> recommendedFees() async {
     return await _liquidSdk.instance!.recommendedFees();
   }

--- a/lib/cubit/chain_swap/chain_swap_cubit.dart
+++ b/lib/cubit/chain_swap/chain_swap_cubit.dart
@@ -112,7 +112,11 @@ class ChainSwapCubit extends Cubit<ChainSwapState> {
     BigInt amount,
     bool outgoing,
     OnchainPaymentLimitsResponse onchainLimits,
+    int balance,
   ) {
+    if (amount.toInt() > balance) {
+      throw const InsufficientLocalBalanceError();
+    }
     var limits = outgoing ? onchainLimits.send : onchainLimits.receive;
     if (amount > limits.maxSat) {
       throw PaymentExceededLimitError(limits.maxSat.toInt());

--- a/lib/cubit/cubit.dart
+++ b/lib/cubit/cubit.dart
@@ -8,5 +8,6 @@ export 'ext/block_builder_extensions.dart';
 export 'input/input_cubit.dart';
 export 'lnurl/lnurl_cubit.dart';
 export 'model/models.dart';
+export 'payment_limits/payment_limits_cubit.dart';
 export 'security/security_cubit.dart';
 export 'user_profile/user_profile_cubit.dart';

--- a/lib/cubit/currency/currency_cubit.dart
+++ b/lib/cubit/currency/currency_cubit.dart
@@ -19,12 +19,10 @@ class CurrencyCubit extends Cubit<CurrencyState> with HydratedMixin {
   }
 
   void _initializeCurrencyCubit() {
-    late final StreamSubscription streamSubscription;
-    streamSubscription = liquidSdk.walletInfoStream.listen(
+    liquidSdk.walletInfoStream.first.then(
       (walletInfo) {
         listFiatCurrencies();
         fetchExchangeRates();
-        streamSubscription.cancel();
       },
     );
   }

--- a/lib/cubit/lnurl/lnurl_cubit.dart
+++ b/lib/cubit/lnurl/lnurl_cubit.dart
@@ -15,30 +15,7 @@ class LnUrlCubit extends Cubit<LnUrlState> {
   final _log = Logger("LnUrlCubit");
   final BreezSDKLiquid _liquidSdk;
 
-  LnUrlCubit(this._liquidSdk) : super(LnUrlState.initial()) {
-    _initializeLnUrlCubit();
-  }
-
-  void _initializeLnUrlCubit() {
-    late final StreamSubscription streamSubscription;
-    streamSubscription = _liquidSdk.walletInfoStream.listen(
-      (walletInfo) {
-        fetchLightningLimits();
-        streamSubscription.cancel();
-      },
-    );
-  }
-
-  Future<LightningPaymentLimitsResponse> fetchLightningLimits() async {
-    try {
-      final limits = await _liquidSdk.instance!.fetchLightningLimits();
-      emit(state.copyWith(limits: limits));
-      return limits;
-    } catch (e) {
-      _log.severe("fetchLightningLimits error", e);
-      rethrow;
-    }
-  }
+  LnUrlCubit(this._liquidSdk) : super(LnUrlState.initial());
 
   Future<LnUrlWithdrawResult> lnurlWithdraw({
     required LnUrlWithdrawRequest req,

--- a/lib/cubit/lnurl/lnurl_cubit.dart
+++ b/lib/cubit/lnurl/lnurl_cubit.dart
@@ -77,7 +77,11 @@ class LnUrlCubit extends Cubit<LnUrlState> {
     BigInt amount,
     bool outgoing,
     LightningPaymentLimitsResponse lightningLimits,
+    int balance,
   ) {
+    if (amount.toInt() > balance) {
+      throw const InsufficientLocalBalanceError();
+    }
     var limits = outgoing ? lightningLimits.send : lightningLimits.receive;
     if (amount > limits.maxSat) {
       throw PaymentExceededLimitError(limits.maxSat.toInt());

--- a/lib/cubit/lnurl/lnurl_cubit.dart
+++ b/lib/cubit/lnurl/lnurl_cubit.dart
@@ -79,7 +79,7 @@ class LnUrlCubit extends Cubit<LnUrlState> {
     LightningPaymentLimitsResponse lightningLimits,
     int balance,
   ) {
-    if (amount.toInt() > balance) {
+    if (outgoing && amount.toInt() > balance) {
       throw const InsufficientLocalBalanceError();
     }
     var limits = outgoing ? lightningLimits.send : lightningLimits.receive;

--- a/lib/cubit/lnurl/lnurl_state.dart
+++ b/lib/cubit/lnurl/lnurl_state.dart
@@ -1,17 +1,9 @@
-import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
-
 class LnUrlState {
-  final LightningPaymentLimitsResponse? limits;
-
-  LnUrlState({this.limits});
+  LnUrlState();
 
   LnUrlState.initial() : this();
 
-  LnUrlState copyWith({
-    LightningPaymentLimitsResponse? limits,
-  }) {
-    return LnUrlState(
-      limits: limits ?? this.limits,
-    );
+  LnUrlState copyWith() {
+    return LnUrlState();
   }
 }

--- a/lib/cubit/model/src/payment/payment_error.dart
+++ b/lib/cubit/model/src/payment/payment_error.dart
@@ -1,25 +1,19 @@
 class PaymentExceededLimitError implements Exception {
-  final BigInt limitSat;
+  final int limitSat;
 
-  const PaymentExceededLimitError(
-    this.limitSat,
-  );
+  const PaymentExceededLimitError(this.limitSat);
 }
 
 class PaymentBelowLimitError implements Exception {
-  final BigInt limitSat;
+  final int limitSat;
 
-  const PaymentBelowLimitError(
-    this.limitSat,
-  );
+  const PaymentBelowLimitError(this.limitSat);
 }
 
 class PaymentBelowReserveError implements Exception {
   final int reserveAmount;
 
-  const PaymentBelowReserveError(
-    this.reserveAmount,
-  );
+  const PaymentBelowReserveError(this.reserveAmount);
 }
 
 class InsufficientLocalBalanceError implements Exception {
@@ -29,25 +23,19 @@ class InsufficientLocalBalanceError implements Exception {
 class PaymentBelowSetupFeesError implements Exception {
   final int setupFees;
 
-  const PaymentBelowSetupFeesError(
-    this.setupFees,
-  );
+  const PaymentBelowSetupFeesError(this.setupFees);
 }
 
-class PaymentExceedLiquidityError implements Exception {
-  final BigInt limitSat;
+class PaymentExceedededLiquidityError implements Exception {
+  final int limitSat;
 
-  const PaymentExceedLiquidityError(
-    this.limitSat,
-  );
+  const PaymentExceedededLiquidityError(this.limitSat);
 }
 
-class PaymentExcededLiqudityChannelCreationNotPossibleError implements Exception {
-  final BigInt limitSat;
+class PaymentExceededLiquidityChannelCreationNotPossibleError implements Exception {
+  final int limitSat;
 
-  const PaymentExcededLiqudityChannelCreationNotPossibleError(
-    this.limitSat,
-  );
+  const PaymentExceededLiquidityChannelCreationNotPossibleError(this.limitSat);
 }
 
-class NoChannelCreationZeroLiqudityError implements Exception {}
+class NoChannelCreationZeroLiquidityError implements Exception {}

--- a/lib/cubit/payment_limits/payment_limits_cubit.dart
+++ b/lib/cubit/payment_limits/payment_limits_cubit.dart
@@ -1,5 +1,7 @@
 library payment_limits_cubit;
 
+import 'dart:async';
+
 import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
@@ -20,8 +22,10 @@ class PaymentLimitsCubit extends Cubit<PaymentLimitsState> {
     _refreshPaymentLimitsOnResume();
   }
 
+  StreamSubscription<FGBGType>? fgBgEventsStreamSubscription;
+
   void _refreshPaymentLimitsOnResume() {
-    FGBGEvents.stream.listen((event) {
+    fgBgEventsStreamSubscription = FGBGEvents.stream.listen((event) {
       if (event == FGBGType.foreground) {
         _fetchPaymentLimits();
       }
@@ -33,6 +37,12 @@ class PaymentLimitsCubit extends Cubit<PaymentLimitsState> {
       fetchLightningLimits();
       fetchOnchainLimits();
     });
+  }
+
+  @override
+  Future<void> close() {
+    fgBgEventsStreamSubscription?.cancel();
+    return super.close();
   }
 
   Future<LightningPaymentLimitsResponse> fetchLightningLimits() async {

--- a/lib/cubit/payment_limits/payment_limits_cubit.dart
+++ b/lib/cubit/payment_limits/payment_limits_cubit.dart
@@ -1,0 +1,63 @@
+library payment_limits_cubit;
+
+import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:flutter_fgbg/flutter_fgbg.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:l_breez/cubit/payment_limits/payment_limits_state.dart';
+import 'package:l_breez/utils/exceptions.dart';
+import 'package:logging/logging.dart';
+
+export 'payment_limits_state.dart';
+
+class PaymentLimitsCubit extends Cubit<PaymentLimitsState> {
+  final _log = Logger("PaymentLimitsCubit");
+  final BreezSDKLiquid _liquidSdk;
+
+  PaymentLimitsCubit(this._liquidSdk) : super(PaymentLimitsState.initial()) {
+    _fetchPaymentLimits();
+    _refreshPaymentLimitsOnResume();
+  }
+
+  void _refreshPaymentLimitsOnResume() {
+    FGBGEvents.stream.listen((event) {
+      if (event == FGBGType.foreground) {
+        _fetchPaymentLimits();
+      }
+    });
+  }
+
+  void _fetchPaymentLimits() {
+    _liquidSdk.walletInfoStream.first.then((walletInfo) {
+      fetchLightningLimits();
+      fetchOnchainLimits();
+    });
+  }
+
+  Future<LightningPaymentLimitsResponse> fetchLightningLimits() async {
+    try {
+      final lightningPaymentLimits = await _liquidSdk.instance!.fetchLightningLimits();
+      emit(state.copyWith(lightningPaymentLimits: lightningPaymentLimits, errorMessage: ""));
+      return lightningPaymentLimits;
+    } catch (e) {
+      _log.severe("fetchLightningLimits error", e);
+      final texts = getSystemAppLocalizations();
+      emit(state.copyWith(lightningPaymentLimits: null, errorMessage: extractExceptionMessage(e, texts)));
+      rethrow;
+    }
+  }
+
+  Future<OnchainPaymentLimitsResponse> fetchOnchainLimits() async {
+    try {
+      final onchainPaymentLimits = await _liquidSdk.instance!.fetchOnchainLimits();
+      emit(state.copyWith(onchainPaymentLimits: onchainPaymentLimits, errorMessage: ""));
+      return onchainPaymentLimits;
+    } catch (e) {
+      _log.severe("fetchOnchainLimits error", e);
+      final texts = getSystemAppLocalizations();
+      emit(state.copyWith(onchainPaymentLimits: null, errorMessage: extractExceptionMessage(e, texts)));
+      rethrow;
+    }
+  }
+}

--- a/lib/cubit/payment_limits/payment_limits_cubit.dart
+++ b/lib/cubit/payment_limits/payment_limits_cubit.dart
@@ -38,12 +38,13 @@ class PaymentLimitsCubit extends Cubit<PaymentLimitsState> {
   Future<LightningPaymentLimitsResponse> fetchLightningLimits() async {
     try {
       final lightningPaymentLimits = await _liquidSdk.instance!.fetchLightningLimits();
-      emit(state.copyWith(lightningPaymentLimits: lightningPaymentLimits, errorMessage: ""));
+      _emitState(state.copyWith(lightningPaymentLimits: lightningPaymentLimits, errorMessage: ""));
       return lightningPaymentLimits;
     } catch (e) {
       _log.severe("fetchLightningLimits error", e);
       final texts = getSystemAppLocalizations();
-      emit(state.copyWith(lightningPaymentLimits: null, errorMessage: extractExceptionMessage(e, texts)));
+      _emitState(
+          state.copyWith(lightningPaymentLimits: null, errorMessage: extractExceptionMessage(e, texts)));
       rethrow;
     }
   }
@@ -51,13 +52,19 @@ class PaymentLimitsCubit extends Cubit<PaymentLimitsState> {
   Future<OnchainPaymentLimitsResponse> fetchOnchainLimits() async {
     try {
       final onchainPaymentLimits = await _liquidSdk.instance!.fetchOnchainLimits();
-      emit(state.copyWith(onchainPaymentLimits: onchainPaymentLimits, errorMessage: ""));
+      _emitState(state.copyWith(onchainPaymentLimits: onchainPaymentLimits, errorMessage: ""));
       return onchainPaymentLimits;
     } catch (e) {
       _log.severe("fetchOnchainLimits error", e);
       final texts = getSystemAppLocalizations();
-      emit(state.copyWith(onchainPaymentLimits: null, errorMessage: extractExceptionMessage(e, texts)));
+      _emitState(state.copyWith(onchainPaymentLimits: null, errorMessage: extractExceptionMessage(e, texts)));
       rethrow;
+    }
+  }
+
+  void _emitState(PaymentLimitsState state) {
+    if (!isClosed) {
+      emit(state);
     }
   }
 }

--- a/lib/cubit/payment_limits/payment_limits_cubit.dart
+++ b/lib/cubit/payment_limits/payment_limits_cubit.dart
@@ -38,13 +38,12 @@ class PaymentLimitsCubit extends Cubit<PaymentLimitsState> {
   Future<LightningPaymentLimitsResponse> fetchLightningLimits() async {
     try {
       final lightningPaymentLimits = await _liquidSdk.instance!.fetchLightningLimits();
-      _emitState(state.copyWith(lightningPaymentLimits: lightningPaymentLimits, errorMessage: ""));
+      emit(state.copyWith(lightningPaymentLimits: lightningPaymentLimits, errorMessage: ""));
       return lightningPaymentLimits;
     } catch (e) {
       _log.severe("fetchLightningLimits error", e);
       final texts = getSystemAppLocalizations();
-      _emitState(
-          state.copyWith(lightningPaymentLimits: null, errorMessage: extractExceptionMessage(e, texts)));
+      emit(state.copyWith(lightningPaymentLimits: null, errorMessage: extractExceptionMessage(e, texts)));
       rethrow;
     }
   }
@@ -52,19 +51,20 @@ class PaymentLimitsCubit extends Cubit<PaymentLimitsState> {
   Future<OnchainPaymentLimitsResponse> fetchOnchainLimits() async {
     try {
       final onchainPaymentLimits = await _liquidSdk.instance!.fetchOnchainLimits();
-      _emitState(state.copyWith(onchainPaymentLimits: onchainPaymentLimits, errorMessage: ""));
+      emit(state.copyWith(onchainPaymentLimits: onchainPaymentLimits, errorMessage: ""));
       return onchainPaymentLimits;
     } catch (e) {
       _log.severe("fetchOnchainLimits error", e);
       final texts = getSystemAppLocalizations();
-      _emitState(state.copyWith(onchainPaymentLimits: null, errorMessage: extractExceptionMessage(e, texts)));
+      emit(state.copyWith(onchainPaymentLimits: null, errorMessage: extractExceptionMessage(e, texts)));
       rethrow;
     }
   }
 
-  void _emitState(PaymentLimitsState state) {
+  @override
+  void emit(PaymentLimitsState state) {
     if (!isClosed) {
-      emit(state);
+      super.emit(state);
     }
   }
 }

--- a/lib/cubit/payment_limits/payment_limits_state.dart
+++ b/lib/cubit/payment_limits/payment_limits_state.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+
+class PaymentLimitsState {
+  final LightningPaymentLimitsResponse? lightningPaymentLimits;
+  final OnchainPaymentLimitsResponse? onchainPaymentLimits;
+  final String errorMessage;
+
+  PaymentLimitsState({
+    this.lightningPaymentLimits,
+    this.onchainPaymentLimits,
+    this.errorMessage = "",
+  });
+
+  PaymentLimitsState.initial() : this();
+
+  bool get hasError => errorMessage.isNotEmpty;
+
+  PaymentLimitsState copyWith({
+    LightningPaymentLimitsResponse? lightningPaymentLimits,
+    OnchainPaymentLimitsResponse? onchainPaymentLimits,
+    String? errorMessage,
+  }) {
+    return PaymentLimitsState(
+      lightningPaymentLimits: lightningPaymentLimits ?? this.lightningPaymentLimits,
+      onchainPaymentLimits: onchainPaymentLimits ?? this.onchainPaymentLimits,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}

--- a/lib/handlers/input_handler/src/input_handler.dart
+++ b/lib/handlers/input_handler/src/input_handler.dart
@@ -87,11 +87,11 @@ class InputHandler extends Handler {
     if (inputState is InvoiceInputState) {
       return handleInvoice(context, inputState.invoice);
     } else if (inputState is LnUrlPayInputState) {
-      handlePayRequest(context, firstPaymentItemKey, inputState.data);
+      return handlePayRequest(context, firstPaymentItemKey, inputState.data);
     } else if (inputState is LnUrlWithdrawInputState) {
-      handleWithdrawRequest(context, inputState.data);
+      return handleWithdrawRequest(context, inputState.data);
     } else if (inputState is LnUrlAuthInputState) {
-      handleAuthRequest(context, inputState.data);
+      return handleAuthRequest(context, inputState.data);
     } else if (inputState is LnUrlErrorInputState) {
       throw inputState.data.reason;
     } else if (inputState is BitcoinAddressInputState) {

--- a/lib/routes/chainswap/receive/receive_chainswap_page.dart
+++ b/lib/routes/chainswap/receive/receive_chainswap_page.dart
@@ -222,7 +222,9 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
   }
 
   void _validateSwap(int amount, bool outgoing) {
+    final accountState = context.read<AccountCubit>().state;
+    final balance = accountState.balance;
     final chainSwapCubit = context.read<ChainSwapCubit>();
-    return chainSwapCubit.validateSwap(BigInt.from(amount), outgoing, _onchainPaymentLimits);
+    return chainSwapCubit.validateSwap(BigInt.from(amount), outgoing, _onchainPaymentLimits, balance);
   }
 }

--- a/lib/routes/chainswap/receive/receive_chainswap_page.dart
+++ b/lib/routes/chainswap/receive/receive_chainswap_page.dart
@@ -115,6 +115,7 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
                             texts: texts,
                             bitcoinCurrency: currencyState.bitcoinCurrency,
                             focusNode: _amountFocusNode,
+                            autofocus: true,
                             controller: _amountController,
                             validatorFn: (v) => validatePayment(v),
                             style: theme.FieldTextStyle.textStyle,

--- a/lib/routes/chainswap/receive/receive_chainswap_page.dart
+++ b/lib/routes/chainswap/receive/receive_chainswap_page.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -6,6 +7,7 @@ import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/chainswap/receive/chainswap_qr_dialog.dart';
 import 'package:l_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
+import 'package:l_breez/utils/min_font_size.dart';
 import 'package:l_breez/utils/payment_validator.dart';
 import 'package:l_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
@@ -82,17 +84,19 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
 
           _onchainPaymentLimits = snapshot.onchainPaymentLimits!;
 
-          return Form(
-            key: _formKey,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 40.0),
-              child: Scrollbar(
-                child: SingleChildScrollView(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.max,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      /* TODO: Liquid - Disabled until description is passable to payment data
+          return BlocBuilder<CurrencyCubit, CurrencyState>(
+            builder: (context, currencyState) {
+              return Form(
+                key: _formKey,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 40.0),
+                  child: Scrollbar(
+                    child: SingleChildScrollView(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.max,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          /* TODO: Liquid - Disabled until description is passable to payment data
                       TextFormField(
                         controller: _descriptionController,
                         keyboardType: TextInputType.multiline,
@@ -105,9 +109,8 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
                         ),
                         style: theme.FieldTextStyle.textStyle,
                       ),*/
-                      BlocBuilder<CurrencyCubit, CurrencyState>(
-                        builder: (context, currencyState) {
-                          return AmountFormField(
+
+                          AmountFormField(
                             context: context,
                             texts: texts,
                             bitcoinCurrency: currencyState.bitcoinCurrency,
@@ -115,14 +118,46 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
                             controller: _amountController,
                             validatorFn: (v) => validatePayment(v),
                             style: theme.FieldTextStyle.textStyle,
-                          );
-                        },
+                          ),
+                          Container(
+                            width: MediaQuery.of(context).size.width,
+                            height: 164,
+                            padding: const EdgeInsets.only(top: 16.0),
+                            child: GestureDetector(
+                              child: Column(
+                                mainAxisAlignment: MainAxisAlignment.start,
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  AutoSizeText(
+                                    texts.invoice_receive_label(
+                                      currencyState.bitcoinCurrency.format(
+                                        _onchainPaymentLimits.receive.maxSat.toInt(),
+                                      ),
+                                    ),
+                                    style: theme.textStyle,
+                                    maxLines: 1,
+                                    minFontSize: MinFontSize(context).minFontSize,
+                                  ),
+                                ],
+                              ),
+                              onTap: () {
+                                setState(() {
+                                  _amountController.text = currencyState.bitcoinCurrency.format(
+                                    _onchainPaymentLimits.receive.maxSat.toInt(),
+                                    includeDisplayName: false,
+                                    userInput: true,
+                                  );
+                                });
+                              },
+                            ),
+                          )
+                        ],
                       ),
-                    ],
+                    ),
                   ),
                 ),
-              ),
-            ),
+              );
+            },
           );
         },
       ),

--- a/lib/routes/chainswap/receive/receive_chainswap_page.dart
+++ b/lib/routes/chainswap/receive/receive_chainswap_page.dart
@@ -1,6 +1,5 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
@@ -30,7 +29,7 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
   final _formKey = GlobalKey<FormState>();
   final _scaffoldKey = GlobalKey<ScaffoldState>();
 
-  final _descriptionController = TextEditingController();
+  //final _descriptionController = TextEditingController();
   final _amountController = TextEditingController();
   final _amountFocusNode = FocusNode();
   var _doneAction = KeyboardDoneAction();
@@ -110,6 +109,7 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
                     mainAxisSize: MainAxisSize.max,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      /* TODO: Liquid - Disabled until description is passable to payment data
                       TextFormField(
                         controller: _descriptionController,
                         keyboardType: TextInputType.multiline,
@@ -121,7 +121,7 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
                           labelText: texts.invoice_description_label,
                         ),
                         style: theme.FieldTextStyle.textStyle,
-                      ),
+                      ),*/
                       BlocBuilder<CurrencyCubit, CurrencyState>(
                         builder: (context, currencyState) {
                           return AmountFormField(

--- a/lib/routes/chainswap/send/send_chainswap_form.dart
+++ b/lib/routes/chainswap/send/send_chainswap_form.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
@@ -6,6 +8,7 @@ import 'package:l_breez/routes/chainswap/send/validator_holder.dart';
 import 'package:l_breez/routes/chainswap/send/widgets/bitcoin_address_text_form_field.dart';
 import 'package:l_breez/routes/chainswap/send/widgets/withdraw_funds_amount_text_form_field.dart';
 import 'package:l_breez/routes/chainswap/send/withdraw_funds_model.dart';
+import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/widgets/amount_form_field/sat_amount_form_field_formatter.dart';
 import 'package:logging/logging.dart';
 
@@ -87,7 +90,7 @@ class _SendChainSwapFormState extends State<SendChainSwapForm> {
               balance: widget.paymentLimits.send.maxSat,
               policy: WithdrawFundsPolicy(
                 WithdrawKind.withdrawFunds,
-                widget.paymentLimits.send.minSat,
+                BigInt.from(max(liquidMinimumPaymentAmountSat, widget.paymentLimits.send.minSat.toInt())),
                 widget.paymentLimits.send.maxSat,
               ),
             ),

--- a/lib/routes/chainswap/send/send_chainswap_form.dart
+++ b/lib/routes/chainswap/send/send_chainswap_form.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
@@ -8,7 +6,6 @@ import 'package:l_breez/routes/chainswap/send/validator_holder.dart';
 import 'package:l_breez/routes/chainswap/send/widgets/bitcoin_address_text_form_field.dart';
 import 'package:l_breez/routes/chainswap/send/widgets/withdraw_funds_amount_text_form_field.dart';
 import 'package:l_breez/routes/chainswap/send/withdraw_funds_model.dart';
-import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/widgets/amount_form_field/sat_amount_form_field_formatter.dart';
 import 'package:logging/logging.dart';
 
@@ -90,7 +87,7 @@ class _SendChainSwapFormState extends State<SendChainSwapForm> {
               balance: widget.paymentLimits.send.maxSat,
               policy: WithdrawFundsPolicy(
                 WithdrawKind.withdrawFunds,
-                BigInt.from(max(liquidMinimumPaymentAmountSat, widget.paymentLimits.send.minSat.toInt())),
+                widget.paymentLimits.send.minSat,
                 widget.paymentLimits.send.maxSat,
               ),
             ),

--- a/lib/routes/chainswap/send/send_chainswap_form_page.dart
+++ b/lib/routes/chainswap/send/send_chainswap_form_page.dart
@@ -15,15 +15,15 @@ import 'package:logging/logging.dart';
 final _log = Logger("SendChainSwapFormPage");
 
 class SendChainSwapFormPage extends StatefulWidget {
-  final BitcoinAddressData? btcAddressData;
   final BitcoinCurrency bitcoinCurrency;
   final OnchainPaymentLimitsResponse paymentLimits;
+  final BitcoinAddressData? btcAddressData;
 
   const SendChainSwapFormPage({
     super.key,
-    this.btcAddressData,
     required this.bitcoinCurrency,
     required this.paymentLimits,
+    this.btcAddressData,
   });
 
   @override

--- a/lib/routes/chainswap/send/send_chainswap_page.dart
+++ b/lib/routes/chainswap/send/send_chainswap_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/chainswap/send/send_chainswap_form_page.dart';
-import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
 import 'package:l_breez/widgets/loader.dart';
 
@@ -22,30 +21,9 @@ class SendChainSwapPage extends StatefulWidget {
 class _SendChainSwapPageState extends State<SendChainSwapPage> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
 
-  Future<OnchainPaymentLimitsResponse>? _onchainPaymentLimitsFuture;
-  @override
-  void initState() {
-    super.initState();
-    _fetchOnchainLimits();
-  }
-
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
-      _fetchOnchainLimits();
-    }
-  }
-
-  Future _fetchOnchainLimits() async {
-    final chainSwapCubit = context.read<ChainSwapCubit>();
-    setState(() {
-      _onchainPaymentLimitsFuture = chainSwapCubit.fetchOnchainLimits();
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
     final texts = context.texts();
-    final themeData = Theme.of(context);
 
     return Scaffold(
       key: _scaffoldKey,
@@ -53,23 +31,22 @@ class _SendChainSwapPageState extends State<SendChainSwapPage> {
         leading: const back_button.BackButton(),
         title: Text(texts.bottom_action_bar_send_btc_address),
       ),
-      body: FutureBuilder<OnchainPaymentLimitsResponse>(
-        future: _onchainPaymentLimitsFuture,
-        builder: (BuildContext context, AsyncSnapshot<OnchainPaymentLimitsResponse> snapshot) {
+      body: BlocBuilder<PaymentLimitsCubit, PaymentLimitsState>(
+        builder: (BuildContext context, PaymentLimitsState snapshot) {
           if (snapshot.hasError) {
             return Center(
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(32, 0, 32, 0),
                 child: Text(
-                  texts.reverse_swap_upstream_generic_error_message(
-                    extractExceptionMessage(snapshot.error!, texts),
-                  ),
+                  texts.reverse_swap_upstream_generic_error_message(snapshot.errorMessage),
                   textAlign: TextAlign.center,
                 ),
               ),
             );
           }
-          if (snapshot.connectionState != ConnectionState.done && !snapshot.hasData) {
+          if (snapshot.onchainPaymentLimits == null) {
+            final themeData = Theme.of(context);
+
             return Center(
               child: Loader(
                 color: themeData.primaryColor.withOpacity(0.5),
@@ -80,8 +57,8 @@ class _SendChainSwapPageState extends State<SendChainSwapPage> {
           var currencyState = context.read<CurrencyCubit>().state;
           return SendChainSwapFormPage(
             bitcoinCurrency: currencyState.bitcoinCurrency,
+            paymentLimits: snapshot.onchainPaymentLimits!,
             btcAddressData: widget.btcAddressData,
-            paymentLimits: snapshot.data!,
           );
         },
       ),

--- a/lib/routes/chainswap/send/widgets/withdraw_funds_amount_text_form_field.dart
+++ b/lib/routes/chainswap/send/widgets/withdraw_funds_amount_text_form_field.dart
@@ -28,10 +28,10 @@ class WithdrawFundsAmountTextFormField extends AmountFormField {
               validatePayment: (amount, outgoing) {
                 _log.info("Validating $amount $policy");
                 if (amount < policy.minValue.toInt()) {
-                  throw PaymentBelowLimitError(policy.minValue);
+                  throw PaymentBelowLimitError(policy.minValue.toInt());
                 }
                 if (amount > policy.maxValue.toInt()) {
-                  throw PaymentExceededLimitError(policy.maxValue);
+                  throw PaymentExceededLimitError(policy.maxValue.toInt());
                 }
                 if (amount > balance.toInt()) {
                   throw const InsufficientLocalBalanceError();

--- a/lib/routes/chainswap/send/widgets/withdraw_funds_amount_text_form_field.dart
+++ b/lib/routes/chainswap/send/widgets/withdraw_funds_amount_text_form_field.dart
@@ -27,14 +27,14 @@ class WithdrawFundsAmountTextFormField extends AmountFormField {
               texts: context.texts(),
               validatePayment: (amount, outgoing) {
                 _log.info("Validating $amount $policy");
+                if (outgoing && amount > balance.toInt()) {
+                  throw const InsufficientLocalBalanceError();
+                }
                 if (amount < policy.minValue.toInt()) {
                   throw PaymentBelowLimitError(policy.minValue.toInt());
                 }
                 if (amount > policy.maxValue.toInt()) {
                   throw PaymentExceededLimitError(policy.maxValue.toInt());
-                }
-                if (amount > balance.toInt()) {
-                  throw const InsufficientLocalBalanceError();
                 }
               },
             ).validateOutgoing(amount);

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -46,7 +46,6 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
   final _amountFocusNode = FocusNode();
   var _doneAction = KeyboardDoneAction();
 
-  Future<LightningPaymentLimitsResponse>? _lightningLimitsFuture;
   late LightningPaymentLimitsResponse _lightningLimits;
 
   @override
@@ -78,7 +77,6 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
   @override
   Widget build(BuildContext context) {
     final texts = context.texts();
-    final themeData = Theme.of(context);
 
     return Scaffold(
       key: _scaffoldKey,

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_liquid/breez_liquid.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
@@ -10,6 +11,7 @@ import 'package:l_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:l_breez/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
+import 'package:l_breez/utils/min_font_size.dart';
 import 'package:l_breez/utils/payment_validator.dart';
 import 'package:l_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
@@ -109,17 +111,19 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
 
           _lightningLimits = snapshot.lightningPaymentLimits!;
 
-          return Form(
-            key: _formKey,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 40.0),
-              child: Scrollbar(
-                child: SingleChildScrollView(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.max,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      /* TODO: Liquid - Disabled until description is passable to payment data
+          return BlocBuilder<CurrencyCubit, CurrencyState>(
+            builder: (context, currencyState) {
+              return Form(
+                key: _formKey,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 40.0),
+                  child: Scrollbar(
+                    child: SingleChildScrollView(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.max,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          /* TODO: Liquid - Disabled until description is passable to payment data
                   TextFormField(
                     controller: _descriptionController,
                     keyboardType: TextInputType.multiline,
@@ -132,9 +136,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                     ),
                     style: theme.FieldTextStyle.textStyle,
                   ),*/
-                      BlocBuilder<CurrencyCubit, CurrencyState>(
-                        builder: (context, currencyState) {
-                          return AmountFormField(
+                          AmountFormField(
                             context: context,
                             texts: texts,
                             bitcoinCurrency: currencyState.bitcoinCurrency,
@@ -142,14 +144,46 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                             controller: _amountController,
                             validatorFn: (v) => validatePayment(v),
                             style: theme.FieldTextStyle.textStyle,
-                          );
-                        },
+                          ),
+                          Container(
+                            width: MediaQuery.of(context).size.width,
+                            height: 164,
+                            padding: const EdgeInsets.only(top: 16.0),
+                            child: GestureDetector(
+                              child: Column(
+                                mainAxisAlignment: MainAxisAlignment.start,
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  AutoSizeText(
+                                    texts.invoice_receive_label(
+                                      currencyState.bitcoinCurrency.format(
+                                        _lightningLimits.receive.maxSat.toInt(),
+                                      ),
+                                    ),
+                                    style: theme.textStyle,
+                                    maxLines: 1,
+                                    minFontSize: MinFontSize(context).minFontSize,
+                                  ),
+                                ],
+                              ),
+                              onTap: () {
+                                setState(() {
+                                  _amountController.text = currencyState.bitcoinCurrency.format(
+                                    _lightningLimits.receive.maxSat.toInt(),
+                                    includeDisplayName: false,
+                                    userInput: true,
+                                  );
+                                });
+                              },
+                            ),
+                          ),
+                        ],
                       ),
-                    ],
+                    ),
                   ),
                 ),
-              ),
-            ),
+              );
+            },
           );
         },
       ),

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -141,6 +141,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                             texts: texts,
                             bitcoinCurrency: currencyState.bitcoinCurrency,
                             focusNode: _amountFocusNode,
+                            autofocus: true,
                             controller: _amountController,
                             validatorFn: (v) => validatePayment(v),
                             style: theme.FieldTextStyle.textStyle,

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -279,7 +279,9 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
   }
 
   void _validatePayment(int amount, bool outgoing) {
+    final accountState = context.read<AccountCubit>().state;
+    final balance = accountState.balance;
     final lnUrlCubit = context.read<LnUrlCubit>();
-    return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits);
+    return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits, balance);
   }
 }

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -1,6 +1,6 @@
+import 'package:breez_liquid/breez_liquid.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
@@ -10,11 +10,13 @@ import 'package:l_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:l_breez/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
+import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/utils/payment_validator.dart';
 import 'package:l_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
 import 'package:l_breez/widgets/flushbar.dart';
 import 'package:l_breez/widgets/keyboard_done_action.dart';
+import 'package:l_breez/widgets/loader.dart';
 import 'package:l_breez/widgets/single_button_bottom_bar.dart';
 import 'package:l_breez/widgets/transparent_page_route.dart';
 import 'package:logging/logging.dart';
@@ -45,6 +47,9 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
   final _amountFocusNode = FocusNode();
   var _doneAction = KeyboardDoneAction();
 
+  Future<LightningPaymentLimitsResponse>? _lightningLimitsFuture;
+  late LightningPaymentLimitsResponse _lightningLimits;
+
   @override
   void initState() {
     super.initState();
@@ -63,6 +68,20 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
         }
       },
     );
+    _fetchLightningLimits();
+  }
+
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _fetchLightningLimits();
+    }
+  }
+
+  Future _fetchLightningLimits() async {
+    final lnuUrlCubit = context.read<LnUrlCubit>();
+    setState(() {
+      _lightningLimitsFuture = lnuUrlCubit.fetchLightningLimits();
+    });
   }
 
   @override
@@ -74,6 +93,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
   @override
   Widget build(BuildContext context) {
     final texts = context.texts();
+    final themeData = Theme.of(context);
 
     return Scaffold(
       key: _scaffoldKey,
@@ -81,16 +101,43 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
         leading: const back_button.BackButton(),
         title: Text(texts.invoice_title),
       ),
-      body: Form(
-        key: _formKey,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 40.0),
-          child: Scrollbar(
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.max,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
+      body: FutureBuilder<LightningPaymentLimitsResponse>(
+        future: _lightningLimitsFuture,
+        builder: (BuildContext context, AsyncSnapshot<LightningPaymentLimitsResponse> snapshot) {
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(32, 0, 32, 0),
+                child: Text(
+                  texts.reverse_swap_upstream_generic_error_message(
+                    extractExceptionMessage(snapshot.error!, texts),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+          if (snapshot.connectionState != ConnectionState.done && !snapshot.hasData) {
+            return Center(
+              child: Loader(
+                color: themeData.primaryColor.withOpacity(0.5),
+              ),
+            );
+          }
+
+          _lightningLimits = snapshot.data!;
+
+          return Form(
+            key: _formKey,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 40.0),
+              child: Scrollbar(
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.max,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      /* TODO: Liquid - Disabled until description is passable to payment data
                   TextFormField(
                     controller: _descriptionController,
                     keyboardType: TextInputType.multiline,
@@ -102,25 +149,27 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                       labelText: texts.invoice_description_label,
                     ),
                     style: theme.FieldTextStyle.textStyle,
+                  ),*/
+                      BlocBuilder<CurrencyCubit, CurrencyState>(
+                        builder: (context, currencyState) {
+                          return AmountFormField(
+                            context: context,
+                            texts: texts,
+                            bitcoinCurrency: currencyState.bitcoinCurrency,
+                            focusNode: _amountFocusNode,
+                            controller: _amountController,
+                            validatorFn: (v) => validatePayment(v),
+                            style: theme.FieldTextStyle.textStyle,
+                          );
+                        },
+                      ),
+                    ],
                   ),
-                  BlocBuilder<CurrencyCubit, CurrencyState>(
-                    builder: (context, currencyState) {
-                      return AmountFormField(
-                        context: context,
-                        texts: texts,
-                        bitcoinCurrency: currencyState.bitcoinCurrency,
-                        focusNode: _amountFocusNode,
-                        controller: _amountController,
-                        validatorFn: (v) => validatePayment(v),
-                        style: theme.FieldTextStyle.textStyle,
-                      );
-                    },
-                  ),
-                ],
+                ),
               ),
             ),
-          ),
-        ),
+          );
+        },
       ),
       bottomNavigationBar: SingleButtonBottomBar(
         stickToBottom: true,
@@ -230,7 +279,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
   }
 
   void _validatePayment(int amount, bool outgoing) {
-    var accountCubit = context.read<AccountCubit>();
-    return accountCubit.validatePayment(amount, outgoing);
+    final lnUrlCubit = context.read<LnUrlCubit>();
+    return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits);
   }
 }

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -142,8 +142,10 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
   Future<void> _withdraw(
     LnUrlWithdrawRequestData data,
   ) async {
-    _log.info("Withdraw request: description=${data.defaultDescription}, k1=${data.k1}, "
-        "min=${data.minWithdrawable}, max=${data.maxWithdrawable}");
+    _log.info(
+      "Withdraw request: description=${data.defaultDescription}, k1=${data.k1}, "
+      "min=${data.minWithdrawable}, max=${data.maxWithdrawable}",
+    );
     final CurrencyCubit currencyCubit = context.read<CurrencyCubit>();
 
     final navigator = Navigator.of(context);

--- a/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
@@ -143,8 +143,8 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
           onPressed: () {
             final amount = widget.data.maxSendable.toInt() ~/ 1000;
             _log.info("LNURL payment of $amount sats where "
-                "min is ${widget.data.minSendable} msats "
-                "and max is ${widget.data.maxSendable} msats.");
+                "min is ${widget.data.minSendable.toInt() * 1000} sats "
+                "and max is ${widget.data.maxSendable.toInt() * 1000} sats.");
             Navigator.pop(context, LNURLPaymentInfo(amount: amount));
           },
           child: Text(

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -18,8 +18,8 @@ Future<LNURLPageResult?> handlePayRequest(
   GlobalKey firstPaymentItemKey,
   LnUrlPayRequestData data,
 ) async {
-  final lnUrlState = context.read<LnUrlCubit>().state;
-  final minSat = lnUrlState.limits?.send.minSat.toInt();
+  final paymentLimitsState = context.read<PaymentLimitsCubit>().state;
+  final minSat = paymentLimitsState.lightningPaymentLimits?.send.minSat.toInt();
   if (minSat != null && data.maxSendable.toInt() ~/ 1000 < minSat) {
     throw Exception("Payment is below network limit of $minSat sats.");
   }

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -10,6 +10,7 @@ import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:l_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
 import 'package:l_breez/widgets/route.dart';
 import 'package:logging/logging.dart';
+import 'package:service_injector/service_injector.dart';
 
 final _log = Logger("HandleLNURLPayRequest");
 
@@ -26,18 +27,25 @@ Future<LNURLPageResult?> handlePayRequest(
 
   LNURLPaymentInfo? paymentInfo;
   bool fixedAmount = data.minSendable == data.maxSendable;
+  final paymentLimitsCubit = PaymentLimitsCubit(ServiceInjector().liquidSDK);
   if (fixedAmount && !(data.commentAllowed > 0)) {
     // Show dialog if payment is of fixed amount with no payer comment allowed
     paymentInfo = await showDialog<LNURLPaymentInfo>(
       useRootNavigator: false,
       context: context,
       barrierDismissible: false,
-      builder: (_) => LNURLPaymentDialog(data: data),
+      builder: (_) => BlocProvider(
+        create: (BuildContext context) => paymentLimitsCubit,
+        child: LNURLPaymentDialog(data: data),
+      ),
     );
   } else {
     paymentInfo = await Navigator.of(context).push<LNURLPaymentInfo>(
       FadeInRoute(
-        builder: (_) => LNURLPaymentPage(data: data),
+        builder: (_) => BlocProvider(
+          create: (BuildContext context) => paymentLimitsCubit,
+          child: LNURLPaymentPage(data: data),
+        ),
       ),
     );
   }

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -20,7 +20,7 @@ Future<LNURLPageResult?> handlePayRequest(
   LnUrlPayRequestData data,
 ) async {
   if (data.maxSendable.toInt() ~/ 1000 < liquidMinimumPaymentAmountSat) {
-    throw Exception("Payment is below Liquid network limits, $liquidMinimumPaymentAmountSat sats.");
+    throw Exception("Payment is below network limit of $liquidMinimumPaymentAmountSat sats.");
   }
 
   LNURLPaymentInfo? paymentInfo;

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -7,7 +7,6 @@ import 'package:l_breez/routes/lnurl/payment/lnurl_payment_info.dart';
 import 'package:l_breez/routes/lnurl/payment/lnurl_payment_page.dart';
 import 'package:l_breez/routes/lnurl/payment/success_action/success_action_dialog.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
-import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
 import 'package:l_breez/widgets/route.dart';
 import 'package:logging/logging.dart';
@@ -19,8 +18,10 @@ Future<LNURLPageResult?> handlePayRequest(
   GlobalKey firstPaymentItemKey,
   LnUrlPayRequestData data,
 ) async {
-  if (data.maxSendable.toInt() ~/ 1000 < liquidMinimumPaymentAmountSat) {
-    throw Exception("Payment is below network limit of $liquidMinimumPaymentAmountSat sats.");
+  final lnUrlState = context.read<LnUrlCubit>().state;
+  final minSat = lnUrlState.limits?.send.minSat.toInt();
+  if (minSat != null && data.maxSendable.toInt() ~/ 1000 < minSat) {
+    throw Exception("Payment is below network limit of $minSat sats.");
   }
 
   LNURLPaymentInfo? paymentInfo;

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -7,6 +7,7 @@ import 'package:l_breez/routes/lnurl/payment/lnurl_payment_info.dart';
 import 'package:l_breez/routes/lnurl/payment/lnurl_payment_page.dart';
 import 'package:l_breez/routes/lnurl/payment/success_action/success_action_dialog.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
+import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
 import 'package:l_breez/widgets/route.dart';
 import 'package:logging/logging.dart';
@@ -18,6 +19,10 @@ Future<LNURLPageResult?> handlePayRequest(
   GlobalKey firstPaymentItemKey,
   LnUrlPayRequestData data,
 ) async {
+  if (data.maxSendable.toInt() ~/ 1000 < liquidMinimumPaymentAmountSat) {
+    throw Exception("Payment is below Liquid network limits, $liquidMinimumPaymentAmountSat sats.");
+  }
+
   LNURLPaymentInfo? paymentInfo;
   bool fixedAmount = data.minSendable == data.maxSendable;
   if (fixedAmount && !(data.commentAllowed > 0)) {

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -147,6 +147,7 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
                     bitcoinCurrency: currencyState.bitcoinCurrency,
                     controller: _amountController,
                     validatorFn: validatePayment,
+                    autofocus: !fixedAmount,
                     enabled: !fixedAmount,
                     readOnly: fixedAmount,
                   ),

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -137,7 +137,13 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
                         TextSpan(
                           text: texts.lnurl_fetch_invoice_min(
                             currencyState.bitcoinCurrency.format(
-                              (widget.data.minSendable.toInt() ~/ 1000),
+                              max(
+                                liquidMinimumPaymentAmountSat,
+                                max(
+                                  context.read<LnUrlCubit>().state.limits?.send.minSat.toInt() ?? 0,
+                                  widget.data.minSendable.toInt() ~/ 1000,
+                                ),
+                              ),
                             ),
                           ),
                           recognizer: TapGestureRecognizer()
@@ -253,7 +259,8 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
     }
 
     final minSendable = (limits != null)
-        ? max(limits.maxSat.toInt(), widget.data.minSendable.toInt() ~/ 1000)
+        ? max(liquidMinimumPaymentAmountSat,
+            max(limits.minSat.toInt(), widget.data.minSendable.toInt() ~/ 1000))
         : widget.data.minSendable.toInt() ~/ 1000;
     if (amount < minSendable) {
       return texts.lnurl_payment_page_error_below_limit(minSendable);

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -11,6 +11,7 @@ import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/lnurl/payment/lnurl_payment_info.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_metadata.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
+import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/utils/payment_validator.dart';
 import 'package:l_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
@@ -127,9 +128,7 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
               ),
               if (!fixedAmount) ...[
                 Padding(
-                  padding: const EdgeInsets.only(
-                    top: 8,
-                  ),
+                  padding: const EdgeInsets.only(top: 8),
                   child: RichText(
                     text: TextSpan(
                       style: theme.FieldTextStyle.labelStyle,
@@ -234,8 +233,8 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
             final amount = currencyCubit.state.bitcoinCurrency.parse(_amountController.text);
             final comment = _commentController.text;
             _log.info("LNURL payment of $amount sats where "
-                "min is ${widget.data.minSendable} msats "
-                "and max is ${widget.data.maxSendable} msats."
+                "min is ${widget.data.minSendable.toInt() ~/ 1000} sats "
+                "and max is ${widget.data.maxSendable.toInt() ~/ 1000} sats."
                 "with comment $comment");
             Navigator.pop(context, LNURLPaymentInfo(amount: amount, comment: comment));
           }

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -14,6 +14,7 @@ import 'package:l_breez/theme/theme_provider.dart' as theme;
 import 'package:l_breez/utils/payment_validator.dart';
 import 'package:l_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
+import 'package:l_breez/widgets/loader.dart';
 import 'package:l_breez/widgets/single_button_bottom_bar.dart';
 import 'package:logging/logging.dart';
 
@@ -74,8 +75,6 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
             includeDisplayName: false,
           );
         }
-        final lnurlCubit = context.read<LnUrlCubit>();
-        _lightningLimits = await lnurlCubit.fetchLightningLimits();
       },
     );
   }
@@ -96,130 +95,157 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
         // Todo: Use domain from request data
         title: Text(texts.lnurl_fetch_invoice_pay_to_payee(Uri.parse(widget.data.callback).host)),
       ),
-      body: Form(
-        key: _formKey,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16.0, 24.0, 16.0, 0.0),
-          child: Column(
-            mainAxisSize: MainAxisSize.max,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (widget.data.commentAllowed > 0) ...[
-                TextFormField(
-                  controller: _commentController,
-                  keyboardType: TextInputType.multiline,
-                  textInputAction: TextInputAction.done,
-                  maxLines: null,
-                  maxLength: widget.data.commentAllowed.toInt(),
-                  maxLengthEnforcement: MaxLengthEnforcement.enforced,
-                  decoration: InputDecoration(
-                    labelText: texts.lnurl_payment_page_comment,
-                  ),
-                )
-              ],
-              AmountFormField(
-                context: context,
-                texts: texts,
-                bitcoinCurrency: currencyState.bitcoinCurrency,
-                controller: _amountController,
-                validatorFn: validatePayment,
-                enabled: !fixedAmount,
-                readOnly: fixedAmount,
+      body: BlocBuilder<PaymentLimitsCubit, PaymentLimitsState>(
+        builder: (BuildContext context, PaymentLimitsState snapshot) {
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(32, 0, 32, 0),
+                child: Text(
+                  texts.reverse_swap_upstream_generic_error_message(snapshot.errorMessage),
+                  textAlign: TextAlign.center,
+                ),
               ),
-              if (!fixedAmount) ...[
-                Padding(
-                  padding: const EdgeInsets.only(top: 8),
-                  child: RichText(
-                    text: TextSpan(
-                      style: theme.FieldTextStyle.labelStyle,
-                      children: <TextSpan>[
-                        TextSpan(
-                          text: texts.lnurl_fetch_invoice_min(
-                            currencyState.bitcoinCurrency.format(
-                              max(
-                                _lightningLimits.send.minSat.toInt(),
-                                widget.data.minSendable.toInt() ~/ 1000,
+            );
+          }
+          if (snapshot.lightningPaymentLimits == null) {
+            final themeData = Theme.of(context);
+
+            return Center(
+              child: Loader(
+                color: themeData.primaryColor.withOpacity(0.5),
+              ),
+            );
+          }
+
+          _lightningLimits = snapshot.lightningPaymentLimits!;
+
+          return Form(
+            key: _formKey,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16.0, 24.0, 16.0, 0.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.max,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (widget.data.commentAllowed > 0) ...[
+                    TextFormField(
+                      controller: _commentController,
+                      keyboardType: TextInputType.multiline,
+                      textInputAction: TextInputAction.done,
+                      maxLines: null,
+                      maxLength: widget.data.commentAllowed.toInt(),
+                      maxLengthEnforcement: MaxLengthEnforcement.enforced,
+                      decoration: InputDecoration(
+                        labelText: texts.lnurl_payment_page_comment,
+                      ),
+                    )
+                  ],
+                  AmountFormField(
+                    context: context,
+                    texts: texts,
+                    bitcoinCurrency: currencyState.bitcoinCurrency,
+                    controller: _amountController,
+                    validatorFn: validatePayment,
+                    enabled: !fixedAmount,
+                    readOnly: fixedAmount,
+                  ),
+                  if (!fixedAmount) ...[
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: RichText(
+                        text: TextSpan(
+                          style: theme.FieldTextStyle.labelStyle,
+                          children: <TextSpan>[
+                            TextSpan(
+                              text: texts.lnurl_fetch_invoice_min(
+                                currencyState.bitcoinCurrency.format(
+                                  max(
+                                    _lightningLimits.send.minSat.toInt(),
+                                    widget.data.minSendable.toInt() ~/ 1000,
+                                  ),
+                                ),
                               ),
+                              recognizer: TapGestureRecognizer()
+                                ..onTap = () {
+                                  _amountController.text = currencyState.bitcoinCurrency.format(
+                                    (widget.data.minSendable.toInt() ~/ 1000),
+                                    includeDisplayName: false,
+                                  );
+                                },
                             ),
-                          ),
-                          recognizer: TapGestureRecognizer()
-                            ..onTap = () {
-                              _amountController.text = currencyState.bitcoinCurrency.format(
-                                (widget.data.minSendable.toInt() ~/ 1000),
-                                includeDisplayName: false,
-                              );
-                            },
+                            TextSpan(
+                              text: texts.lnurl_fetch_invoice_and(
+                                currencyState.bitcoinCurrency.format(
+                                  (widget.data.maxSendable.toInt() ~/ 1000),
+                                ),
+                              ),
+                              recognizer: TapGestureRecognizer()
+                                ..onTap = () {
+                                  _amountController.text = currencyState.bitcoinCurrency.format(
+                                    (widget.data.maxSendable.toInt() ~/ 1000),
+                                    includeDisplayName: false,
+                                  );
+                                },
+                            )
+                          ],
                         ),
-                        TextSpan(
-                          text: texts.lnurl_fetch_invoice_and(
-                            currencyState.bitcoinCurrency.format(
-                              (widget.data.maxSendable.toInt() ~/ 1000),
-                            ),
-                          ),
-                          recognizer: TapGestureRecognizer()
-                            ..onTap = () {
-                              _amountController.text = currencyState.bitcoinCurrency.format(
-                                (widget.data.maxSendable.toInt() ~/ 1000),
-                                includeDisplayName: false,
-                              );
-                            },
-                        )
-                      ],
+                      ),
+                    ),
+                  ],
+                  /*
+                  if (widget.name?.mandatory == true) ...[
+                    TextFormField(
+                      controller: _nameController,
+                      keyboardType: TextInputType.name,
+                      validator: (value) => value != null ? null : texts.breez_avatar_dialog_your_name,
+                    )
+                  ],
+                  if (widget.auth?.mandatory == true) ...[
+                    TextFormField(
+                      controller: _k1Controller,
+                      keyboardType: TextInputType.text,
+                      validator: (value) => value != null ? null : texts.lnurl_payment_page_enter_k1,
+                    )
+                  ],
+                  if (widget.email?.mandatory == true) ...[
+                    TextFormField(
+                      controller: _emailController,
+                      keyboardType: TextInputType.emailAddress,
+                      validator: (value) => value != null
+                          ? EmailValidator.validate(value)
+                              ? null
+                              : texts.order_card_country_email_invalid
+                          : texts.order_card_country_email_empty,
+                    )
+                  ],
+                  if (widget.identifier?.mandatory == true) ...[
+                    TextFormField(
+                      controller: _identifierController,
+                    )
+                  ],
+                   */
+                  Container(
+                    width: MediaQuery.of(context).size.width,
+                    height: 48,
+                    padding: const EdgeInsets.only(top: 16.0),
+                    child: LNURLMetadataText(metadataMap: metadataMap),
+                  ),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(0, 10, 0, 22),
+                      child: Center(
+                        child: LNURLMetadataImage(
+                          base64String: base64String,
+                        ),
+                      ),
                     ),
                   ),
-                ),
-              ],
-              /*
-              if (widget.name?.mandatory == true) ...[
-                TextFormField(
-                  controller: _nameController,
-                  keyboardType: TextInputType.name,
-                  validator: (value) => value != null ? null : texts.breez_avatar_dialog_your_name,
-                )
-              ],
-              if (widget.auth?.mandatory == true) ...[
-                TextFormField(
-                  controller: _k1Controller,
-                  keyboardType: TextInputType.text,
-                  validator: (value) => value != null ? null : texts.lnurl_payment_page_enter_k1,
-                )
-              ],
-              if (widget.email?.mandatory == true) ...[
-                TextFormField(
-                  controller: _emailController,
-                  keyboardType: TextInputType.emailAddress,
-                  validator: (value) => value != null
-                      ? EmailValidator.validate(value)
-                          ? null
-                          : texts.order_card_country_email_invalid
-                      : texts.order_card_country_email_empty,
-                )
-              ],
-              if (widget.identifier?.mandatory == true) ...[
-                TextFormField(
-                  controller: _identifierController,
-                )
-              ],
-               */
-              Container(
-                width: MediaQuery.of(context).size.width,
-                height: 48,
-                padding: const EdgeInsets.only(top: 16.0),
-                child: LNURLMetadataText(metadataMap: metadataMap),
+                ],
               ),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(0, 10, 0, 22),
-                  child: Center(
-                    child: LNURLMetadataImage(
-                      base64String: base64String,
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
+            ),
+          );
+        },
       ),
       bottomNavigationBar: SingleButtonBottomBar(
         stickToBottom: true,

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -242,7 +242,6 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
 
   String? validatePayment(int amount) {
     final texts = context.texts();
-    final lnUrlCubit = context.read<LnUrlCubit>();
     final currencyState = context.read<CurrencyCubit>().state;
 
     final maxSendable = widget.data.maxSendable.toInt() ~/ 1000;
@@ -256,13 +255,16 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
     }
 
     return PaymentValidator(
-      validatePayment: (amount, outgoing) => lnUrlCubit.validateLnUrlPayment(
-        BigInt.from(amount),
-        outgoing,
-        _lightningLimits,
-      ),
+      validatePayment: _validatePayment,
       currency: currencyState.bitcoinCurrency,
       texts: context.texts(),
     ).validateOutgoing(amount);
+  }
+
+  void _validatePayment(int amount, bool outgoing) {
+    final accountState = context.read<AccountCubit>().state;
+    final balance = accountState.balance;
+    final lnUrlCubit = context.read<LnUrlCubit>();
+    return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits, balance);
   }
 }

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
@@ -142,9 +142,11 @@ class _LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> with SingleTi
     final description = widget.requestData.defaultDescription;
 
     try {
-      _log.info("LNURL withdraw of ${widget.amountSats} sats where "
-          "min is ${widget.requestData.minWithdrawable} msats "
-          "and max is ${widget.requestData.maxWithdrawable} msats.");
+      _log.info(
+        "LNURL withdraw of ${widget.amountSats} sats where "
+        "min is ${widget.requestData.minWithdrawable.toInt() ~/ 1000} sats "
+        "and max is ${widget.requestData.maxWithdrawable.toInt() ~/ 1000} sats.",
+      );
       final req = LnUrlWithdrawRequest(
         amountMsat: BigInt.from(widget.amountSats * 1000),
         data: widget.requestData,

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -25,12 +25,12 @@ Future<LNURLPageResult?> handleWithdrawRequest(
   if (minSat != null && requestData.maxWithdrawable.toInt() ~/ 1000 < minSat) {
     throw Exception("Payment is below network limit of $minSat sats.");
   }
-  final paymentLimitsCubit = PaymentLimitsCubit(ServiceInjector().liquidSDK);
+
   Completer<LNURLPageResult?> completer = Completer();
   Navigator.of(context).push(
     MaterialPageRoute(
       builder: (_) => BlocProvider(
-        create: (BuildContext context) => paymentLimitsCubit,
+        create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().liquidSDK),
         child: CreateInvoicePage(
           requestData: requestData,
           onFinish: (LNURLPageResult? response) {

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -19,7 +19,7 @@ Future<LNURLPageResult?> handleWithdrawRequest(
   LnUrlWithdrawRequestData requestData,
 ) async {
   if (requestData.maxWithdrawable.toInt() ~/ 1000 < liquidMinimumPaymentAmountSat) {
-    throw Exception("Payment is below Liquid network limits, $liquidMinimumPaymentAmountSat sats.");
+    throw Exception("Payment is below network limit of $liquidMinimumPaymentAmountSat sats.");
   }
 
   Completer<LNURLPageResult?> completer = Completer();

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -12,6 +12,7 @@ import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:l_breez/widgets/error_dialog.dart';
 import 'package:l_breez/widgets/transparent_page_route.dart';
 import 'package:logging/logging.dart';
+import 'package:service_injector/service_injector.dart';
 
 final _log = Logger("HandleLNURLWithdrawPageResult");
 
@@ -24,16 +25,19 @@ Future<LNURLPageResult?> handleWithdrawRequest(
   if (minSat != null && requestData.maxWithdrawable.toInt() ~/ 1000 < minSat) {
     throw Exception("Payment is below network limit of $minSat sats.");
   }
-
+  final paymentLimitsCubit = PaymentLimitsCubit(ServiceInjector().liquidSDK);
   Completer<LNURLPageResult?> completer = Completer();
   Navigator.of(context).push(
     MaterialPageRoute(
-      builder: (_) => CreateInvoicePage(
-        requestData: requestData,
-        onFinish: (LNURLPageResult? response) {
-          completer.complete(response);
-          Navigator.of(context).popUntil((route) => route.settings.name == Home.routeName);
-        },
+      builder: (_) => BlocProvider(
+        create: (BuildContext context) => paymentLimitsCubit,
+        child: CreateInvoicePage(
+          requestData: requestData,
+          onFinish: (LNURLPageResult? response) {
+            completer.complete(response);
+            Navigator.of(context).popUntil((route) => route.settings.name == Home.routeName);
+          },
+        ),
       ),
     ),
   );

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -4,7 +4,7 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
-import 'package:l_breez/cubit/lnurl/lnurl_cubit.dart';
+import 'package:l_breez/cubit/payment_limits/payment_limits_cubit.dart';
 import 'package:l_breez/routes/create_invoice/create_invoice_page.dart';
 import 'package:l_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:l_breez/routes/home/home_page.dart';
@@ -19,8 +19,8 @@ Future<LNURLPageResult?> handleWithdrawRequest(
   BuildContext context,
   LnUrlWithdrawRequestData requestData,
 ) async {
-  final lnUrlState = context.read<LnUrlCubit>().state;
-  final minSat = lnUrlState.limits?.send.minSat.toInt();
+  final paymentLimitsState = context.read<PaymentLimitsCubit>().state;
+  final minSat = paymentLimitsState.lightningPaymentLimits?.send.minSat.toInt();
   if (minSat != null && requestData.maxWithdrawable.toInt() ~/ 1000 < minSat) {
     throw Exception("Payment is below network limit of $minSat sats.");
   }

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -7,6 +7,7 @@ import 'package:l_breez/routes/create_invoice/create_invoice_page.dart';
 import 'package:l_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:l_breez/routes/home/home_page.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
+import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/widgets/error_dialog.dart';
 import 'package:l_breez/widgets/transparent_page_route.dart';
 import 'package:logging/logging.dart';
@@ -17,6 +18,10 @@ Future<LNURLPageResult?> handleWithdrawRequest(
   BuildContext context,
   LnUrlWithdrawRequestData requestData,
 ) async {
+  if (requestData.maxWithdrawable.toInt() ~/ 1000 < liquidMinimumPaymentAmountSat) {
+    throw Exception("Payment is below Liquid network limits, $liquidMinimumPaymentAmountSat sats.");
+  }
+
   Completer<LNURLPageResult?> completer = Completer();
   Navigator.of(context).push(
     MaterialPageRoute(

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -2,12 +2,13 @@ import 'dart:async';
 
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/cubit/lnurl/lnurl_cubit.dart';
 import 'package:l_breez/routes/create_invoice/create_invoice_page.dart';
 import 'package:l_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:l_breez/routes/home/home_page.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
-import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/widgets/error_dialog.dart';
 import 'package:l_breez/widgets/transparent_page_route.dart';
 import 'package:logging/logging.dart';
@@ -18,8 +19,10 @@ Future<LNURLPageResult?> handleWithdrawRequest(
   BuildContext context,
   LnUrlWithdrawRequestData requestData,
 ) async {
-  if (requestData.maxWithdrawable.toInt() ~/ 1000 < liquidMinimumPaymentAmountSat) {
-    throw Exception("Payment is below network limit of $liquidMinimumPaymentAmountSat sats.");
+  final lnUrlState = context.read<LnUrlCubit>().state;
+  final minSat = lnUrlState.limits?.send.minSat.toInt();
+  if (minSat != null && requestData.maxWithdrawable.toInt() ~/ 1000 < minSat) {
+    throw Exception("Payment is below network limit of $minSat sats.");
   }
 
   Completer<LNURLPageResult?> completer = Completer();

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,0 +1,1 @@
+const liquidMinimumPaymentAmountSat = 1000;

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,1 +1,1 @@
-const liquidMinimumPaymentAmountSat = 1000;
+const maxPaymentAmountSat = 4294967;

--- a/lib/utils/payment_validator.dart
+++ b/lib/utils/payment_validator.dart
@@ -44,7 +44,7 @@ class PaymentValidator {
       return texts.invoice_payment_validator_error_payment_below_limit(
         currency.format(e.reserveAmount),
       );
-    } on PaymentExceedLiquidityError catch (e) {
+    } on PaymentExceedededLiquidityError catch (e) {
       return "Insufficient inbound liquidity (${currency.format(e.limitSat.toInt())})";
     } on InsufficientLocalBalanceError {
       return texts.invoice_payment_validator_error_insufficient_local_balance;
@@ -53,9 +53,9 @@ class PaymentValidator {
       return texts.invoice_payment_validator_error_payment_below_setup_fees_error(
         currency.format(e.setupFees),
       );
-    } on PaymentExcededLiqudityChannelCreationNotPossibleError catch (e) {
+    } on PaymentExceededLiquidityChannelCreationNotPossibleError catch (e) {
       return texts.lnurl_fetch_invoice_error_max(currency.format(e.limitSat.toInt()));
-    } on NoChannelCreationZeroLiqudityError {
+    } on NoChannelCreationZeroLiquidityError {
       return texts.lsp_error_cannot_open_channel;
     } catch (e) {
       _log.info("Got Generic error", e);

--- a/lib/widgets/amount_form_field/amount_form_field.dart
+++ b/lib/widgets/amount_form_field/amount_form_field.dart
@@ -37,10 +37,12 @@ class AmountFormField extends TextFormField {
     super.enabled,
     super.onChanged,
     bool? readOnly,
+    bool? autofocus,
   }) : super(
           keyboardType: TextInputType.numberWithOptions(
             decimal: bitcoinCurrency != BitcoinCurrency.sat,
           ),
+          autofocus: autofocus ?? false,
           decoration: InputDecoration(
             labelText: texts.amount_form_denomination(
               bitcoinCurrency.displayName,

--- a/lib/widgets/payment_dialogs/payment_request_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_dialog.dart
@@ -5,6 +5,7 @@ import 'package:l_breez/models/invoice.dart';
 import 'package:l_breez/widgets/payment_dialogs/payment_confirmation_dialog.dart';
 import 'package:l_breez/widgets/payment_dialogs/payment_request_info_dialog.dart';
 import 'package:l_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
+import 'package:service_injector/service_injector.dart';
 
 enum PaymentRequestState {
   paymentRequest,
@@ -101,16 +102,20 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
         minHeight,
       );
     } else {
-      return PaymentRequestInfoDialog(
-        widget.invoice,
-        () => _onStateChange(PaymentRequestState.userCancelled),
-        () => _onStateChange(PaymentRequestState.waitingForConfirmation),
-        (bolt11, amount) {
-          _amountToPay = amount + widget.invoice.lspFee;
-          _onStateChange(PaymentRequestState.processingPayment);
-        },
-        (map) => _setAmountToPay(map),
-        minHeight,
+      final paymentLimitsCubit = PaymentLimitsCubit(ServiceInjector().liquidSDK);
+      return BlocProvider(
+        create: (BuildContext context) => paymentLimitsCubit,
+        child: PaymentRequestInfoDialog(
+          widget.invoice,
+          () => _onStateChange(PaymentRequestState.userCancelled),
+          () => _onStateChange(PaymentRequestState.waitingForConfirmation),
+          (bolt11, amount) {
+            _amountToPay = amount + widget.invoice.lspFee;
+            _onStateChange(PaymentRequestState.processingPayment);
+          },
+          (map) => _setAmountToPay(map),
+          minHeight,
+        ),
       );
     }
   }

--- a/lib/widgets/payment_dialogs/payment_request_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_dialog.dart
@@ -102,9 +102,8 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
         minHeight,
       );
     } else {
-      final paymentLimitsCubit = PaymentLimitsCubit(ServiceInjector().liquidSDK);
       return BlocProvider(
-        create: (BuildContext context) => paymentLimitsCubit,
+        create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().liquidSDK),
         child: PaymentRequestInfoDialog(
           widget.invoice,
           () => _onStateChange(PaymentRequestState.userCancelled),

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -208,6 +208,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
                 bitcoinCurrency: BitcoinCurrency.fromTickerSymbol(currencyState.bitcoinTicker),
                 iconColor: themeData.primaryIconTheme.color,
                 focusNode: _amountFocusNode,
+                autofocus: true,
                 controller: _invoiceAmountController,
                 validatorFn: PaymentValidator(
                   validatePayment: _validatePayment,

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -2,15 +2,18 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/currency.dart';
 import 'package:l_breez/models/invoice.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
+import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/utils/fiat_conversion.dart';
 import 'package:l_breez/utils/payment_validator.dart';
 import 'package:l_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:l_breez/widgets/breez_avatar.dart';
 import 'package:l_breez/widgets/keyboard_done_action.dart';
+import 'package:l_breez/widgets/loader.dart';
 
 class PaymentRequestInfoDialog extends StatefulWidget {
   final Invoice invoice;
@@ -46,6 +49,9 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
   KeyboardDoneAction? _doneAction;
   bool _showFiatCurrency = false;
 
+  Future<LightningPaymentLimitsResponse>? _lightningLimitsFuture;
+  late LightningPaymentLimitsResponse _lightningLimits;
+
   @override
   void initState() {
     super.initState();
@@ -53,6 +59,20 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
       setState(() {});
     });
     _doneAction = KeyboardDoneAction(focusNodes: [_amountFocusNode]);
+    _fetchLightningLimits();
+  }
+
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _fetchLightningLimits();
+    }
+  }
+
+  Future _fetchLightningLimits() async {
+    final lnuUrlCubit = context.read<LnUrlCubit>();
+    setState(() {
+      _lightningLimitsFuture = lnuUrlCubit.fetchLightningLimits();
+    });
   }
 
   @override
@@ -93,24 +113,26 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
   }
 
   Widget _buildPaymentRequestContent() {
-    return BlocBuilder<CurrencyCubit, CurrencyState>(builder: (c, currencyState) {
-      return BlocBuilder<AccountCubit, AccountState>(
-        builder: (context, account) {
-          List<Widget> children = [];
-          _addIfNotNull(children, _buildPayeeNameWidget());
-          _addIfNotNull(children, _buildRequestPayTextWidget());
-          _addIfNotNull(children, _buildAmountWidget(account, currencyState));
-          _addIfNotNull(children, _buildDescriptionWidget());
-          _addIfNotNull(children, _buildErrorMessage(currencyState));
-          _addIfNotNull(children, _buildActions(currencyState, account));
+    return BlocBuilder<CurrencyCubit, CurrencyState>(
+      builder: (c, currencyState) {
+        return BlocBuilder<AccountCubit, AccountState>(
+          builder: (context, account) {
+            List<Widget> children = [];
+            _addIfNotNull(children, _buildPayeeNameWidget());
+            _addIfNotNull(children, _buildRequestPayTextWidget());
+            _addIfNotNull(children, _buildAmountWidget(account, currencyState));
+            _addIfNotNull(children, _buildDescriptionWidget());
+            _addIfNotNull(children, _buildErrorMessage(currencyState));
+            _addIfNotNull(children, _buildActions(currencyState, account));
 
-          return Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: Column(children: children),
-          );
-        },
-      );
-    });
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Column(children: children),
+            );
+          },
+        );
+      },
+    );
   }
 
   void _addIfNotNull(List<Widget> widgets, Widget? w) {
@@ -146,44 +168,72 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
     final texts = context.texts();
 
     if (widget.invoice.amountMsat == BigInt.zero) {
-      return Theme(
-        data: themeData.copyWith(
-          inputDecorationTheme: InputDecorationTheme(
-            enabledBorder: UnderlineInputBorder(
-              borderSide: theme.greyBorderSide,
+      return FutureBuilder<LightningPaymentLimitsResponse>(
+        future: _lightningLimitsFuture,
+        builder: (BuildContext context, AsyncSnapshot<LightningPaymentLimitsResponse> snapshot) {
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(32, 0, 32, 0),
+                child: Text(
+                  texts.reverse_swap_upstream_generic_error_message(
+                    extractExceptionMessage(snapshot.error!, texts),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+          if (snapshot.connectionState != ConnectionState.done && !snapshot.hasData) {
+            return Center(
+              child: Loader(
+                color: themeData.primaryColor.withOpacity(0.5),
+              ),
+            );
+          }
+
+          _lightningLimits = snapshot.data!;
+
+          return Theme(
+            data: themeData.copyWith(
+              inputDecorationTheme: InputDecorationTheme(
+                enabledBorder: UnderlineInputBorder(
+                  borderSide: theme.greyBorderSide,
+                ),
+              ),
+              hintColor: themeData.dialogTheme.contentTextStyle!.color,
+              colorScheme: ColorScheme.dark(
+                primary: themeData.textTheme.labelLarge!.color!,
+                error: themeData.isLightTheme ? Colors.red : themeData.colorScheme.error,
+              ),
+              primaryColor: themeData.textTheme.labelLarge!.color!,
             ),
-          ),
-          hintColor: themeData.dialogTheme.contentTextStyle!.color,
-          colorScheme: ColorScheme.dark(
-            primary: themeData.textTheme.labelLarge!.color!,
-            error: themeData.isLightTheme ? Colors.red : themeData.colorScheme.error,
-          ),
-          primaryColor: themeData.textTheme.labelLarge!.color!,
-        ),
-        child: Form(
-          autovalidateMode: AutovalidateMode.always,
-          key: _formKey,
-          child: Padding(
-            padding: const EdgeInsets.only(left: 16.0, right: 16.0),
-            child: SizedBox(
-              height: 80.0,
-              child: AmountFormField(
-                context: context,
-                texts: texts,
-                bitcoinCurrency: BitcoinCurrency.fromTickerSymbol(currencyState.bitcoinTicker),
-                iconColor: themeData.primaryIconTheme.color,
-                focusNode: _amountFocusNode,
-                controller: _invoiceAmountController,
-                validatorFn: PaymentValidator(
-                  validatePayment: context.read<AccountCubit>().validatePayment,
-                  currency: currencyState.bitcoinCurrency,
-                  texts: context.texts(),
-                ).validateOutgoing,
-                style: themeData.dialogTheme.contentTextStyle!.copyWith(height: 1.0),
+            child: Form(
+              autovalidateMode: AutovalidateMode.always,
+              key: _formKey,
+              child: Padding(
+                padding: const EdgeInsets.only(left: 16.0, right: 16.0),
+                child: SizedBox(
+                  height: 80.0,
+                  child: AmountFormField(
+                    context: context,
+                    texts: texts,
+                    bitcoinCurrency: BitcoinCurrency.fromTickerSymbol(currencyState.bitcoinTicker),
+                    iconColor: themeData.primaryIconTheme.color,
+                    focusNode: _amountFocusNode,
+                    controller: _invoiceAmountController,
+                    validatorFn: PaymentValidator(
+                      validatePayment: _validatePayment,
+                      currency: currencyState.bitcoinCurrency,
+                      texts: context.texts(),
+                    ).validateOutgoing,
+                    style: themeData.dialogTheme.contentTextStyle!.copyWith(height: 1.0),
+                  ),
+                ),
               ),
             ),
-          ),
-        ),
+          );
+        },
       );
     }
 
@@ -250,7 +300,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
 
   Widget? _buildErrorMessage(CurrencyState currencyState) {
     final validationError = PaymentValidator(
-      validatePayment: context.read<AccountCubit>().validatePayment,
+      validatePayment: _validatePayment,
       currency: currencyState.bitcoinCurrency,
       texts: context.texts(),
     ).validateOutgoing(
@@ -340,5 +390,10 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
       } catch (_) {}
     }
     return amount + widget.invoice.lspFee;
+  }
+
+  void _validatePayment(int amount, bool outgoing) {
+    final lnUrlCubit = context.read<LnUrlCubit>();
+    return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits);
   }
 }

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -290,32 +290,32 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
       )
     ];
 
-    int toPay = amountToPay(currency);
-    //TODO: Liquid
-//    if (toPay > 0 && accState.maxAllowedToPay >= toPay) {
-    actions.add(SimpleDialogOption(
-      onPressed: (() async {
-        if (widget.invoice.amountMsat > BigInt.zero || _formKey.currentState!.validate()) {
-          if (widget.invoice.amountMsat == BigInt.zero) {
-            _amountToPayMap["_amountToPay"] = toPay;
-            _amountToPayMap["_amountToPayStr"] =
-                BitcoinCurrency.fromTickerSymbol(currency.bitcoinTicker).format(amountToPay(currency));
-            widget._setAmountToPay(_amountToPayMap);
-            widget._onWaitingConfirmation();
-          } else {
-            widget._onPaymentApproved(
-              widget.invoice.bolt11,
-              amountToPay(currency),
-            );
+    int toPaySat = amountToPay(currency);
+    actions.add(
+      SimpleDialogOption(
+        onPressed: (() async {
+          if (widget.invoice.amountMsat > BigInt.zero || _formKey.currentState!.validate()) {
+            if (widget.invoice.amountMsat == BigInt.zero) {
+              _amountToPayMap["_amountToPay"] = toPaySat;
+              _amountToPayMap["_amountToPayStr"] =
+                  BitcoinCurrency.fromTickerSymbol(currency.bitcoinTicker).format(amountToPay(currency));
+              widget._setAmountToPay(_amountToPayMap);
+              widget._onWaitingConfirmation();
+            } else {
+              widget._onPaymentApproved(
+                widget.invoice.bolt11,
+                amountToPay(currency),
+              );
+            }
           }
-        }
-      }),
-      child: Text(
-        texts.payment_request_dialog_action_approve,
-        style: themeData.primaryTextTheme.labelLarge,
+        }),
+        child: Text(
+          texts.payment_request_dialog_action_approve,
+          style: themeData.primaryTextTheme.labelLarge,
+        ),
       ),
-    ));
-    //}
+    );
+
     return Theme(
       data: themeData.copyWith(
         splashColor: Colors.transparent,

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -393,7 +393,9 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
   }
 
   void _validatePayment(int amount, bool outgoing) {
+    final accountState = context.read<AccountCubit>().state;
+    final balance = accountState.balance;
     final lnUrlCubit = context.read<LnUrlCubit>();
-    return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits);
+    return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits, balance);
   }
 }

--- a/lib/widgets/payment_dialogs/processing_payment_dialog.dart
+++ b/lib/widgets/payment_dialogs/processing_payment_dialog.dart
@@ -168,12 +168,8 @@ class ProcessingPaymentDialogState extends State<ProcessingPaymentDialog>
           )
         : Dialog(
             child: Container(
-              constraints: BoxConstraints(
-                minHeight: widget.minHeight,
-              ),
-              child: ProcessingPaymentContent(
-                dialogKey: _dialogKey,
-              ),
+              constraints: BoxConstraints(minHeight: widget.minHeight),
+              child: ProcessingPaymentContent(dialogKey: _dialogKey),
             ),
           );
   }


### PR DESCRIPTION
Fixes #59 

This PR addresses unit conversion issues on payment limits & prevents payments that fall below Liquid network minimum payment limit of 1000 sats to be shown to the user.