### PR TITLE
Validate amount against Liquid Network payment limits

### DIFF
--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -12,6 +12,7 @@ import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:l_breez/cubit/account/account_cubit.dart';
 import 'package:l_breez/cubit/model/models.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
+import 'package:l_breez/utils/constants.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:rxdart/rxdart.dart';
@@ -197,33 +198,22 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
     bool outgoing,
   ) {
     _log.info("validatePayment: $amount, $outgoing");
-    /*
     var accState = state;
-    if (amount > accState.maxPaymentAmount) {
-      _log.info("Amount $amount is bigger than maxPaymentAmount ${accState.maxPaymentAmount}");
-      throw PaymentExceededLimitError(accState.maxPaymentAmount);
-    }
-
-    if (!outgoing) {
-      if (accState.maxInboundLiquidity == 0) {
-        throw NoChannelCreationZeroLiqudityError();
-      } else if (accState.maxInboundLiquidity < amount) {
-        throw PaymentExcededLiqudityChannelCreationNotPossibleError(accState.maxInboundLiquidity);
-      } else if (amount > accState.maxInboundLiquidity) {
-        throw PaymentExceedLiquidityError(accState.maxInboundLiquidity);
-      } else if (amount > accState.maxAllowedToReceive) {
-        throw PaymentExceededLimitError(accState.maxAllowedToReceive);
+    if (outgoing) {
+      if (amount > accState.balance) {
+        throw const InsufficientLocalBalanceError();
       }
     }
 
-    if (outgoing && amount > accState.maxAllowedToPay) {
-      _log.info("Outgoing but amount $amount is bigger than ${accState.maxAllowedToPay}");
-      if (accState.reserveAmount > 0) {
-        _log.info("Reserve amount ${accState.reserveAmount}");
-        throw PaymentBelowReserveError(accState.reserveAmount);
-      }
-      throw const InsufficientLocalBalanceError();
-    }*/
+    if (amount > accState.maxPaymentAmountSat) {
+      _log.info("Amount $amount is bigger than maxPaymentAmount ${accState.maxPaymentAmountSat}");
+      throw PaymentExceededLimitError(accState.maxPaymentAmountSat);
+    }
+
+    if (amount < minPaymentAmountSat) {
+      _log.info("Amount $amount is smaller than minPaymentAmountSat $minPaymentAmountSat");
+      throw const PaymentBelowLimitError(minPaymentAmountSat);
+    }
   }
 
   void changePaymentFilter({

--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -12,7 +12,6 @@ import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:l_breez/cubit/account/account_cubit.dart';
 import 'package:l_breez/cubit/model/models.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
-import 'package:l_breez/utils/constants.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:rxdart/rxdart.dart';
@@ -193,10 +192,7 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
 
   // validatePayment is used to validate that outgoing/incoming payments meet the liquidity
   // constraints.
-  void validatePayment(
-    int amount,
-    bool outgoing,
-  ) {
+  void validatePayment(int amount, bool outgoing) {
     _log.info("validatePayment: $amount, $outgoing");
     var accState = state;
     if (outgoing) {
@@ -208,11 +204,6 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
     if (amount > accState.maxPaymentAmountSat) {
       _log.info("Amount $amount is bigger than maxPaymentAmount ${accState.maxPaymentAmountSat}");
       throw PaymentExceededLimitError(accState.maxPaymentAmountSat);
-    }
-
-    if (amount < minPaymentAmountSat) {
-      _log.info("Amount $amount is smaller than minPaymentAmountSat $minPaymentAmountSat");
-      throw const PaymentBelowLimitError(minPaymentAmountSat);
     }
   }
 

--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -19,7 +19,6 @@ import 'package:rxdart/rxdart.dart';
 export 'account_state.dart';
 export 'account_state_assembler.dart';
 
-const maxPaymentAmount = 4294967;
 const nodeSyncInterval = 60;
 
 final _log = Logger("AccountCubit");

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -20,7 +20,7 @@ class AccountState {
   final int walletBalance;
   final int maxAllowedToPay;
   final int maxAllowedToReceive;
-  final int maxPaymentAmount;
+  final int maxPaymentAmountSat;
   final int maxChanReserve;
   final List<String> connectedPeers;
   final int maxInboundLiquidity;
@@ -40,7 +40,7 @@ class AccountState {
     required this.walletBalance,
     required this.maxAllowedToPay,
     required this.maxAllowedToReceive,
-    required this.maxPaymentAmount,
+    required this.maxPaymentAmountSat,
     required this.maxChanReserve,
     required this.connectedPeers,
     required this.maxInboundLiquidity,
@@ -58,7 +58,7 @@ class AccountState {
           blockheight: 0,
           maxAllowedToPay: 0,
           maxAllowedToReceive: 0,
-          maxPaymentAmount: 0,
+          maxPaymentAmountSat: 0,
           maxChanReserve: 0,
           connectedPeers: List.empty(),
           maxInboundLiquidity: 0,
@@ -83,7 +83,7 @@ class AccountState {
     int? walletBalance,
     int? maxAllowedToPay,
     int? maxAllowedToReceive,
-    int? maxPaymentAmount,
+    int? maxPaymentAmountSat,
     int? maxChanReserve,
     List<String>? connectedPeers,
     int? maxInboundLiquidity,
@@ -102,7 +102,7 @@ class AccountState {
       walletBalance: walletBalance ?? this.walletBalance,
       maxAllowedToPay: maxAllowedToPay ?? this.maxAllowedToPay,
       maxAllowedToReceive: maxAllowedToReceive ?? this.maxAllowedToReceive,
-      maxPaymentAmount: maxPaymentAmount ?? this.maxPaymentAmount,
+      maxPaymentAmountSat: maxPaymentAmountSat ?? this.maxPaymentAmountSat,
       blockheight: blockheight ?? this.blockheight,
       maxChanReserve: maxChanReserve ?? this.maxChanReserve,
       connectedPeers: connectedPeers ?? this.connectedPeers,
@@ -131,7 +131,7 @@ class AccountState {
       "walletBalance": walletBalance,
       "maxAllowedToPay": maxAllowedToPay,
       "maxAllowedToReceive": maxAllowedToReceive,
-      "maxPaymentAmount": maxPaymentAmount,
+      "maxPaymentAmount": maxPaymentAmountSat,
       "maxChanReserve": maxChanReserve,
       "maxInboundLiquidity": maxInboundLiquidity,
       "onChainFeeRate": onChainFeeRate,
@@ -153,7 +153,7 @@ class AccountState {
       walletBalance: json["walletBalance"],
       maxAllowedToPay: json["maxAllowedToPay"],
       maxAllowedToReceive: json["maxAllowedToReceive"],
-      maxPaymentAmount: json["maxPaymentAmount"],
+      maxPaymentAmountSat: json["maxPaymentAmount"],
       maxChanReserve: json["maxChanReserve"],
       connectedPeers: <String>[],
       maxInboundLiquidity: json["maxInboundLiquidity"] ?? 0,

--- a/lib/cubit/account/account_state_assembler.dart
+++ b/lib/cubit/account/account_state_assembler.dart
@@ -3,6 +3,7 @@ import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/account/account_cubit.dart';
 import 'package:l_breez/cubit/model/src/payment/payment_filters.dart';
 import 'package:l_breez/models/payment_minutiae.dart';
+import 'package:l_breez/utils/constants.dart';
 
 // assembleAccountState assembles the account state using the local synchronized data.
 AccountState? assembleAccountState(
@@ -23,7 +24,7 @@ AccountState? assembleAccountState(
     balance: walletInfo.balanceSat.toInt(),
     pendingReceive: walletInfo.pendingReceiveSat.toInt(),
     pendingSend: walletInfo.pendingSendSat.toInt(),
-    maxPaymentAmount: maxPaymentAmount,
+    maxPaymentAmountSat: maxPaymentAmountSat,
     onChainFeeRate: 0,
     payments: payments?.map((e) => PaymentMinutiae.fromPayment(e, texts)).toList(),
     paymentFilters: paymentFilters,

--- a/lib/cubit/chain_swap/chain_swap_cubit.dart
+++ b/lib/cubit/chain_swap/chain_swap_cubit.dart
@@ -58,10 +58,10 @@ class ChainSwapCubit extends Cubit<ChainSwapState> {
   ) {
     var limits = outgoing ? onchainLimits.send : onchainLimits.receive;
     if (amount > limits.maxSat) {
-      throw PaymentExceededLimitError(limits.maxSat);
+      throw PaymentExceededLimitError(limits.maxSat.toInt());
     }
     if (amount < limits.minSat) {
-      throw PaymentBelowLimitError(limits.minSat);
+      throw PaymentBelowLimitError(limits.minSat.toInt());
     }
   }
 }

--- a/lib/cubit/lnurl/lnurl_cubit.dart
+++ b/lib/cubit/lnurl/lnurl_cubit.dart
@@ -1,5 +1,7 @@
 library lnurl_cubit;
 
+import 'dart:async';
+
 import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
@@ -12,7 +14,19 @@ class LnUrlCubit extends Cubit<LnUrlState> {
   final _log = Logger("LnUrlCubit");
   final BreezSDKLiquid _liquidSdk;
 
-  LnUrlCubit(this._liquidSdk) : super(LnUrlState.initial());
+  LnUrlCubit(this._liquidSdk) : super(LnUrlState.initial()) {
+    _initializeLnUrlCubit();
+  }
+
+  void _initializeLnUrlCubit() {
+    late final StreamSubscription streamSubscription;
+    streamSubscription = _liquidSdk.walletInfoStream.listen(
+      (walletInfo) {
+        fetchLightningLimits();
+        streamSubscription.cancel();
+      },
+    );
+  }
 
   Future<LightningPaymentLimitsResponse> fetchLightningLimits() async {
     try {

--- a/lib/cubit/lnurl/lnurl_cubit.dart
+++ b/lib/cubit/lnurl/lnurl_cubit.dart
@@ -6,6 +6,7 @@ import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:l_breez/cubit/lnurl/lnurl_state.dart';
+import 'package:l_breez/cubit/model/src/payment/payment_error.dart';
 import 'package:logging/logging.dart';
 
 export 'lnurl_state.dart';
@@ -69,6 +70,20 @@ class LnUrlCubit extends Cubit<LnUrlState> {
     } catch (e) {
       _log.severe("lnurlAuth error", e);
       rethrow;
+    }
+  }
+
+  void validateLnUrlPayment(
+    BigInt amount,
+    bool outgoing,
+    LightningPaymentLimitsResponse lightningLimits,
+  ) {
+    var limits = outgoing ? lightningLimits.send : lightningLimits.receive;
+    if (amount > limits.maxSat) {
+      throw PaymentExceededLimitError(limits.maxSat.toInt());
+    }
+    if (amount < limits.minSat) {
+      throw PaymentBelowLimitError(limits.minSat.toInt());
     }
   }
 }

--- a/lib/cubit/model/src/payment/payment_error.dart
+++ b/lib/cubit/model/src/payment/payment_error.dart
@@ -1,11 +1,11 @@
 class PaymentExceededLimitError implements Exception {
-  final BigInt limitSat;
+  final int limitSat;
 
   const PaymentExceededLimitError(this.limitSat);
 }
 
 class PaymentBelowLimitError implements Exception {
-  final BigInt limitSat;
+  final int limitSat;
 
   const PaymentBelowLimitError(this.limitSat);
 }
@@ -26,21 +26,15 @@ class PaymentBelowSetupFeesError implements Exception {
   const PaymentBelowSetupFeesError(this.setupFees);
 }
 
-  final BigInt limitSat;
 class PaymentExceedededLiquidityError implements Exception {
+  final int limitSat;
 
-  const PaymentExceedLiquidityError(
-    this.limitSat,
-  );
   const PaymentExceedededLiquidityError(this.limitSat);
 }
 
-  final BigInt limitSat;
 class PaymentExceededLiquidityChannelCreationNotPossibleError implements Exception {
+  final int limitSat;
 
-  const PaymentExcededLiqudityChannelCreationNotPossibleError(
-    this.limitSat,
-  );
   const PaymentExceededLiquidityChannelCreationNotPossibleError(this.limitSat);
 }
 

--- a/lib/cubit/model/src/payment/payment_error.dart
+++ b/lib/cubit/model/src/payment/payment_error.dart
@@ -1,25 +1,19 @@
 class PaymentExceededLimitError implements Exception {
   final BigInt limitSat;
 
-  const PaymentExceededLimitError(
-    this.limitSat,
-  );
+  const PaymentExceededLimitError(this.limitSat);
 }
 
 class PaymentBelowLimitError implements Exception {
   final BigInt limitSat;
 
-  const PaymentBelowLimitError(
-    this.limitSat,
-  );
+  const PaymentBelowLimitError(this.limitSat);
 }
 
 class PaymentBelowReserveError implements Exception {
   final int reserveAmount;
 
-  const PaymentBelowReserveError(
-    this.reserveAmount,
-  );
+  const PaymentBelowReserveError(this.reserveAmount);
 }
 
 class InsufficientLocalBalanceError implements Exception {
@@ -29,25 +23,25 @@ class InsufficientLocalBalanceError implements Exception {
 class PaymentBelowSetupFeesError implements Exception {
   final int setupFees;
 
-  const PaymentBelowSetupFeesError(
-    this.setupFees,
-  );
+  const PaymentBelowSetupFeesError(this.setupFees);
 }
 
-class PaymentExceedLiquidityError implements Exception {
   final BigInt limitSat;
+class PaymentExceedededLiquidityError implements Exception {
 
   const PaymentExceedLiquidityError(
     this.limitSat,
   );
+  const PaymentExceedededLiquidityError(this.limitSat);
 }
 
-class PaymentExcededLiqudityChannelCreationNotPossibleError implements Exception {
   final BigInt limitSat;
+class PaymentExceededLiquidityChannelCreationNotPossibleError implements Exception {
 
   const PaymentExcededLiqudityChannelCreationNotPossibleError(
     this.limitSat,
   );
+  const PaymentExceededLiquidityChannelCreationNotPossibleError(this.limitSat);
 }
 
-class NoChannelCreationZeroLiqudityError implements Exception {}
+class NoChannelCreationZeroLiquidityError implements Exception {}

--- a/lib/routes/chainswap/receive/receive_chainswap_page.dart
+++ b/lib/routes/chainswap/receive/receive_chainswap_page.dart
@@ -27,7 +27,7 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
   final _formKey = GlobalKey<FormState>();
   final _scaffoldKey = GlobalKey<ScaffoldState>();
 
-  final _descriptionController = TextEditingController();
+  //final _descriptionController = TextEditingController();
   final _amountController = TextEditingController();
   final _amountFocusNode = FocusNode();
   var _doneAction = KeyboardDoneAction();

--- a/lib/routes/chainswap/receive/receive_chainswap_page.dart
+++ b/lib/routes/chainswap/receive/receive_chainswap_page.dart
@@ -1,6 +1,5 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
@@ -108,6 +107,7 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
                     mainAxisSize: MainAxisSize.max,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      /* TODO: Liquid - Disabled until description is passable to payment data
                       TextFormField(
                         controller: _descriptionController,
                         keyboardType: TextInputType.multiline,
@@ -119,7 +119,7 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
                           labelText: texts.invoice_description_label,
                         ),
                         style: theme.FieldTextStyle.textStyle,
-                      ),
+                      ),*/
                       BlocBuilder<CurrencyCubit, CurrencyState>(
                         builder: (context, currencyState) {
                           return AmountFormField(

--- a/lib/routes/chainswap/send/send_chainswap_form.dart
+++ b/lib/routes/chainswap/send/send_chainswap_form.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
@@ -8,7 +6,6 @@ import 'package:l_breez/routes/chainswap/send/validator_holder.dart';
 import 'package:l_breez/routes/chainswap/send/widgets/bitcoin_address_text_form_field.dart';
 import 'package:l_breez/routes/chainswap/send/widgets/withdraw_funds_amount_text_form_field.dart';
 import 'package:l_breez/routes/chainswap/send/withdraw_funds_model.dart';
-import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/widgets/amount_form_field/sat_amount_form_field_formatter.dart';
 import 'package:logging/logging.dart';
 
@@ -90,7 +87,7 @@ class _SendChainSwapFormState extends State<SendChainSwapForm> {
               balance: widget.paymentLimits.send.maxSat,
               policy: WithdrawFundsPolicy(
                 WithdrawKind.withdrawFunds,
-                BigInt.from(max(minPaymentAmountSat, widget.paymentLimits.send.minSat.toInt())),
+                widget.paymentLimits.send.minSat,
                 widget.paymentLimits.send.maxSat,
               ),
             ),

--- a/lib/routes/chainswap/send/send_chainswap_form.dart
+++ b/lib/routes/chainswap/send/send_chainswap_form.dart
@@ -90,7 +90,7 @@ class _SendChainSwapFormState extends State<SendChainSwapForm> {
               balance: widget.paymentLimits.send.maxSat,
               policy: WithdrawFundsPolicy(
                 WithdrawKind.withdrawFunds,
-                BigInt.from(max(liquidMinimumPaymentAmountSat, widget.paymentLimits.send.minSat.toInt())),
+                BigInt.from(max(minPaymentAmountSat, widget.paymentLimits.send.minSat.toInt())),
                 widget.paymentLimits.send.maxSat,
               ),
             ),

--- a/lib/routes/chainswap/send/widgets/withdraw_funds_amount_text_form_field.dart
+++ b/lib/routes/chainswap/send/widgets/withdraw_funds_amount_text_form_field.dart
@@ -28,10 +28,10 @@ class WithdrawFundsAmountTextFormField extends AmountFormField {
               validatePayment: (amount, outgoing) {
                 _log.info("Validating $amount $policy");
                 if (amount < policy.minValue.toInt()) {
-                  throw PaymentBelowLimitError(policy.minValue);
+                  throw PaymentBelowLimitError(policy.minValue.toInt());
                 }
                 if (amount > policy.maxValue.toInt()) {
-                  throw PaymentExceededLimitError(policy.maxValue);
+                  throw PaymentExceededLimitError(policy.maxValue.toInt());
                 }
                 if (amount > balance.toInt()) {
                   throw const InsufficientLocalBalanceError();

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -1,6 +1,5 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
@@ -89,6 +88,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                 mainAxisSize: MainAxisSize.max,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  /* TODO: Liquid - Disabled until description is passable to payment data
                   TextFormField(
                     controller: _descriptionController,
                     keyboardType: TextInputType.multiline,
@@ -100,7 +100,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                       labelText: texts.invoice_description_label,
                     ),
                     style: theme.FieldTextStyle.textStyle,
-                  ),
+                  ),*/
                   BlocBuilder<CurrencyCubit, CurrencyState>(
                     builder: (context, currencyState) {
                       return AmountFormField(

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -7,7 +7,6 @@ import 'package:l_breez/routes/lnurl/payment/lnurl_payment_info.dart';
 import 'package:l_breez/routes/lnurl/payment/lnurl_payment_page.dart';
 import 'package:l_breez/routes/lnurl/payment/success_action/success_action_dialog.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
-import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
 import 'package:l_breez/widgets/route.dart';
 import 'package:logging/logging.dart';
@@ -19,8 +18,10 @@ Future<LNURLPageResult?> handlePayRequest(
   GlobalKey firstPaymentItemKey,
   LnUrlPayRequestData data,
 ) async {
-  if (data.maxSendable.toInt() ~/ 1000 < liquidMinimumPaymentAmountSat) {
-    throw Exception("Payment is below network limit of $liquidMinimumPaymentAmountSat sats.");
+  final lnUrlState = context.read<LnUrlCubit>().state;
+  final minSat = lnUrlState.limits?.send.minSat.toInt();
+  if (minSat != null && data.maxSendable.toInt() ~/ 1000 < minSat) {
+    throw Exception("Payment is below network limit of $minSat sats.");
   }
 
   LNURLPaymentInfo? paymentInfo;

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -11,7 +11,6 @@ import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/lnurl/payment/lnurl_payment_info.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_metadata.dart';
 import 'package:l_breez/theme/theme_provider.dart' as theme;
-import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/utils/payment_validator.dart';
 import 'package:l_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
@@ -60,6 +59,7 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
   final _identifierController = TextEditingController();
    */
   late final bool fixedAmount;
+  late LightningPaymentLimitsResponse _lightningLimits;
 
   @override
   void initState() {
@@ -75,7 +75,7 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
           );
         }
         final lnurlCubit = context.read<LnUrlCubit>();
-        await lnurlCubit.fetchLightningLimits();
+        _lightningLimits = await lnurlCubit.fetchLightningLimits();
       },
     );
   }
@@ -137,11 +137,8 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
                           text: texts.lnurl_fetch_invoice_min(
                             currencyState.bitcoinCurrency.format(
                               max(
-                                minPaymentAmountSat,
-                                max(
-                                  context.read<LnUrlCubit>().state.limits?.send.minSat.toInt() ?? 0,
-                                  widget.data.minSendable.toInt() ~/ 1000,
-                                ),
+                                _lightningLimits.send.minSat.toInt(),
+                                widget.data.minSendable.toInt() ~/ 1000,
                               ),
                             ),
                           ),
@@ -245,27 +242,25 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
 
   String? validatePayment(int amount) {
     final texts = context.texts();
-    final accountCubit = context.read<AccountCubit>();
+    final lnUrlCubit = context.read<LnUrlCubit>();
     final currencyState = context.read<CurrencyCubit>().state;
-    final lnurlState = context.read<LnUrlCubit>().state;
-    final limits = lnurlState.limits?.send;
 
-    final maxSendable = (limits != null)
-        ? min(limits.maxSat.toInt(), widget.data.maxSendable.toInt() ~/ 1000)
-        : widget.data.maxSendable.toInt() ~/ 1000;
+    final maxSendable = widget.data.maxSendable.toInt() ~/ 1000;
     if (amount > maxSendable) {
       return texts.lnurl_payment_page_error_exceeds_limit(maxSendable);
     }
 
-    final minSendable = (limits != null)
-        ? max(minPaymentAmountSat, max(limits.minSat.toInt(), widget.data.minSendable.toInt() ~/ 1000))
-        : widget.data.minSendable.toInt() ~/ 1000;
+    final minSendable = widget.data.minSendable.toInt() ~/ 1000;
     if (amount < minSendable) {
       return texts.lnurl_payment_page_error_below_limit(minSendable);
     }
 
     return PaymentValidator(
-      validatePayment: accountCubit.validatePayment,
+      validatePayment: (amount, outgoing) => lnUrlCubit.validateLnUrlPayment(
+        BigInt.from(amount),
+        outgoing,
+        _lightningLimits,
+      ),
       currency: currencyState.bitcoinCurrency,
       texts: context.texts(),
     ).validateOutgoing(amount);

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -137,7 +137,7 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
                           text: texts.lnurl_fetch_invoice_min(
                             currencyState.bitcoinCurrency.format(
                               max(
-                                liquidMinimumPaymentAmountSat,
+                                minPaymentAmountSat,
                                 max(
                                   context.read<LnUrlCubit>().state.limits?.send.minSat.toInt() ?? 0,
                                   widget.data.minSendable.toInt() ~/ 1000,
@@ -258,8 +258,7 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
     }
 
     final minSendable = (limits != null)
-        ? max(liquidMinimumPaymentAmountSat,
-            max(limits.minSat.toInt(), widget.data.minSendable.toInt() ~/ 1000))
+        ? max(minPaymentAmountSat, max(limits.minSat.toInt(), widget.data.minSendable.toInt() ~/ 1000))
         : widget.data.minSendable.toInt() ~/ 1000;
     if (amount < minSendable) {
       return texts.lnurl_payment_page_error_below_limit(minSendable);

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -2,11 +2,12 @@ import 'dart:async';
 
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/cubit/lnurl/lnurl_cubit.dart';
 import 'package:l_breez/routes/create_invoice/create_invoice_page.dart';
 import 'package:l_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
-import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/widgets/error_dialog.dart';
 import 'package:l_breez/widgets/transparent_page_route.dart';
 import 'package:logging/logging.dart';
@@ -17,8 +18,10 @@ Future<LNURLPageResult?> handleWithdrawRequest(
   BuildContext context,
   LnUrlWithdrawRequestData requestData,
 ) async {
-  if (requestData.maxWithdrawable.toInt() ~/ 1000 < liquidMinimumPaymentAmountSat) {
-    throw Exception("Payment is below network limit of $liquidMinimumPaymentAmountSat sats.");
+  final lnUrlState = context.read<LnUrlCubit>().state;
+  final minSat = lnUrlState.limits?.send.minSat.toInt();
+  if (minSat != null && requestData.maxWithdrawable.toInt() ~/ 1000 < minSat) {
+    throw Exception("Payment is below network limit of $minSat sats.");
   }
 
   Completer<LNURLPageResult?> completer = Completer();

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,1 +1,4 @@
-const liquidMinimumPaymentAmountSat = 1000;
+const maxPaymentAmountSat = 4294967;
+
+// Minimum payment amount on Liquid Network
+const minPaymentAmountSat = 1000;

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,4 +1,1 @@
 const maxPaymentAmountSat = 4294967;
-
-// Minimum payment amount on Liquid Network
-const minPaymentAmountSat = 1000;

--- a/lib/utils/payment_validator.dart
+++ b/lib/utils/payment_validator.dart
@@ -44,7 +44,7 @@ class PaymentValidator {
       return texts.invoice_payment_validator_error_payment_below_limit(
         currency.format(e.reserveAmount),
       );
-    } on PaymentExceedLiquidityError catch (e) {
+    } on PaymentExceedededLiquidityError catch (e) {
       return "Insufficient inbound liquidity (${currency.format(e.limitSat.toInt())})";
     } on InsufficientLocalBalanceError {
       return texts.invoice_payment_validator_error_insufficient_local_balance;
@@ -53,9 +53,9 @@ class PaymentValidator {
       return texts.invoice_payment_validator_error_payment_below_setup_fees_error(
         currency.format(e.setupFees),
       );
-    } on PaymentExcededLiqudityChannelCreationNotPossibleError catch (e) {
+    } on PaymentExceededLiquidityChannelCreationNotPossibleError catch (e) {
       return texts.lnurl_fetch_invoice_error_max(currency.format(e.limitSat.toInt()));
-    } on NoChannelCreationZeroLiqudityError {
+    } on NoChannelCreationZeroLiquidityError {
       return texts.lsp_error_cannot_open_channel;
     } catch (e) {
       _log.info("Got Generic error", e);


### PR DESCRIPTION
Fixes #55

### Changelist
- Validate payments against 
  - Liquid Network payment limits
  - Account balance for outgoing payments
- `PaymentError`:
  - Convert `PaymentError` amount types to int
  - Address typos on PaymentError's
- Disable description fields until it's passable to payment data
- Rename `liquidMinimumPaymentAmountSat` & move `maxPaymentAmount` to constants