### PR TITLE
Remove credentials from secure storage on failed register attempts

### DIFF
--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -126,6 +126,9 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
       });
     } catch (e) {
       _log.warning("failed to connect to breez lib", e);
+      if (!isRestore) {
+        await _credentialsManager.removeMnemonic();
+      }
       emit(state.copyWith(connectionStatus: ConnectionStatus.disconnected));
       rethrow;
     }

--- a/packages/credentials_manager/lib/src/credentials_manager.dart
+++ b/packages/credentials_manager/lib/src/credentials_manager.dart
@@ -34,6 +34,15 @@ class CredentialsManager {
     }
   }
 
+  Future<void> removeMnemonic() async {
+    try {
+      await keyChain.delete(accountMnemonic);
+      _log.info("Removed credentials successfully");
+    } catch (err) {
+      throw Exception(err.toString());
+    }
+  }
+
   // Helper methods
   Future<void> _storeMnemonic(String mnemonic) async {
     await keyChain.write(accountMnemonic, mnemonic);


### PR DESCRIPTION
Closes #98

If a network connectivity caused registering to fail, removal of credentials from secure storage prevents connecting with those credentials on next app startup.