### PR TITLE
Treat Network as disconnected if the only returned connectivity result is `ConnectivityResult.vpn`

### DIFF
--- a/lib/cubit/connectivity/connectivity_state.dart
+++ b/lib/cubit/connectivity/connectivity_state.dart
@@ -8,7 +8,9 @@ class ConnectivityState {
   const ConnectivityState.initial() : connectivityResult = null;
 
   bool get hasNetworkConnection =>
-      connectivityResult != null && !connectivityResult!.contains(ConnectivityResult.none);
+      connectivityResult != null &&
+      (!connectivityResult!.contains(ConnectivityResult.none) ||
+          connectivityResult!.every((result) => result == ConnectivityResult.vpn));
 
   ConnectivityState copyWith({
     List<ConnectivityResult>? connectivityResult,


### PR DESCRIPTION
Closes #104