### PR TITLE
Default to latest published Liquid SDK plugin version on build workflows

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -8,10 +8,9 @@ on:
         type: boolean
         default: false
       liquid-sdk-plugin-version:
-        description: 'Version for the published Liquid SDK plugin (MAJOR.MINOR.BUILD). Default = "main"'
+        description: 'Version for the published Liquid SDK plugin (MAJOR.MINOR.BUILD). Defaults to latest published version on "breez/breez-sdk-liquid-flutter"'
         required: false
         type: string
-        default: 'main'
       liquid-sdk-ref:
         description: 'Liquid SDK commit/tag/branch reference when not using a published plugin. Default = "main"'
         required: false
@@ -33,6 +32,20 @@ jobs:
       liquid-sdk-plugin-version: ${{ inputs.liquid-sdk-plugin-version }}
       liquid-sdk-ref: ${{ inputs.liquid-sdk-ref }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'breez/breez-sdk-liquid-flutter'
+
+      - name: Fetch all tags
+        run: git fetch --tags
+
+      - name: Get the latest tag
+        id: get_latest_tag
+        run: |
+          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "::set-output name=liquid-sdk-plugin-version::$latest_tag"
+
       - run: echo "set pre-setup output variables"
 
   setup:
@@ -66,7 +79,7 @@ jobs:
         working-directory: lbreez
         run: |
           mv pubspec_overrides.yaml.workflow pubspec_overrides.yaml
-          sed -i.bak -e 's/ref:.*/ref: v${{ needs.setup.outputs.liquid-sdk-plugin-version }}/' pubspec_overrides.yaml
+          sed -i.bak -e 's/ref:.*/ref: ${{ needs.setup.outputs.liquid-sdk-plugin-version }}/' pubspec_overrides.yaml
           rm pubspec_overrides.yaml.bak
 
       - name: Decode Keystore

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -11,6 +11,7 @@ on:
         description: 'Version for the published Liquid SDK plugin "v(MAJOR.MINOR.BUILD)". Defaults to latest published version on "breez/breez-sdk-liquid-flutter"'
         required: false
         type: string
+        default: ''
       liquid-sdk-ref:
         description: 'Liquid SDK commit/tag/branch reference when not using a published plugin. Default = "main"'
         required: false
@@ -33,15 +34,13 @@ jobs:
       liquid-sdk-ref: ${{ inputs.liquid-sdk-ref }}
     steps:
       - name: Checkout repository
+        if:  ${{ needs.pre-setup.outputs.liquid-sdk-plugin-version == ''}}
         uses: actions/checkout@v4
         with:
           repository: 'breez/breez-sdk-liquid-flutter'
 
-      - name: Fetch all tags
-        run: git fetch --tags
-
-      - name: Get the latest tag
-        id: get_latest_tag
+      - name: Get the latest tag and set 'liquid-sdk-plugin-version'
+        if:  ${{ needs.pre-setup.outputs.liquid-sdk-plugin-version == ''}}
         run: |
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
           echo "::set-output name=liquid-sdk-plugin-version::$latest_tag"

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -8,7 +8,7 @@ on:
         type: boolean
         default: false
       liquid-sdk-plugin-version:
-        description: 'Version for the published Liquid SDK plugin (MAJOR.MINOR.BUILD). Defaults to latest published version on "breez/breez-sdk-liquid-flutter"'
+        description: 'Version for the published Liquid SDK plugin "v(MAJOR.MINOR.BUILD)". Defaults to latest published version on "breez/breez-sdk-liquid-flutter"'
         required: false
         type: string
       liquid-sdk-ref:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -11,6 +11,7 @@ on:
         description: 'Version for the published Liquid SDK plugin "v(MAJOR.MINOR.BUILD)". Defaults to latest published version on "breez/breez-sdk-liquid-flutter"'
         required: false
         type: string
+        default: ''
       liquid-sdk-ref:
         description: 'Liquid SDK commit/tag/branch reference when not using a published plugin. Default = "main"'
         required: false
@@ -32,15 +33,13 @@ jobs:
       liquid-sdk-ref: ${{ inputs.liquid-sdk-ref }}
     steps:
       - name: Checkout repository
+        if:  ${{ needs.pre-setup.outputs.liquid-sdk-plugin-version == ''}}
         uses: actions/checkout@v4
         with:
           repository: 'breez/breez-sdk-liquid-flutter'
 
-      - name: Fetch all tags
-        run: git fetch --tags
-
-      - name: Get the latest tag
-        id: get_latest_tag
+      - name: Get the latest tag and set 'liquid-sdk-plugin-version'
+        if:  ${{ needs.pre-setup.outputs.liquid-sdk-plugin-version == ''}}
         run: |
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
           echo "::set-output name=liquid-sdk-plugin-version::$latest_tag"

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -8,10 +8,9 @@ on:
         type: boolean
         default: false
       liquid-sdk-plugin-version:
-        description: 'Version for the published Liquid SDK plugin (MAJOR.MINOR.BUILD). Default = "main"'
+        description: 'Version for the published Liquid SDK plugin (MAJOR.MINOR.BUILD). Defaults to latest published version on "breez/breez-sdk-liquid-flutter"'
         required: false
         type: string
-        default: 'main'
       liquid-sdk-ref:
         description: 'Liquid SDK commit/tag/branch reference when not using a published plugin. Default = "main"'
         required: false
@@ -32,6 +31,20 @@ jobs:
       liquid-sdk-plugin-version: ${{ inputs.liquid-sdk-plugin-version }}
       liquid-sdk-ref: ${{ inputs.liquid-sdk-ref }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'breez/breez-sdk-liquid-flutter'
+
+      - name: Fetch all tags
+        run: git fetch --tags
+
+      - name: Get the latest tag
+        id: get_latest_tag
+        run: |
+          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "::set-output name=liquid-sdk-plugin-version::$latest_tag"
+
       - run: echo "set pre-setup output variables"
 
   setup:
@@ -75,7 +88,7 @@ jobs:
         working-directory: lbreez
         run: |
           mv pubspec_overrides.yaml.workflow pubspec_overrides.yaml
-          sed -i.bak -e 's/ref:.*/ref: v${{ needs.setup.outputs.liquid-sdk-plugin-version }}/' pubspec_overrides.yaml
+          sed -i.bak -e 's/ref:.*/ref: ${{ needs.setup.outputs.liquid-sdk-plugin-version }}/' pubspec_overrides.yaml
           rm pubspec_overrides.yaml.bak
 
       - name: Install rust

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -8,7 +8,7 @@ on:
         type: boolean
         default: false
       liquid-sdk-plugin-version:
-        description: 'Version for the published Liquid SDK plugin (MAJOR.MINOR.BUILD). Defaults to latest published version on "breez/breez-sdk-liquid-flutter"'
+        description: 'Version for the published Liquid SDK plugin "v(MAJOR.MINOR.BUILD)". Defaults to latest published version on "breez/breez-sdk-liquid-flutter"'
         required: false
         type: string
       liquid-sdk-ref:


### PR DESCRIPTION
Fetches latest released tag on [breez/breez-sdk-liquid-flutter](https://github.com/breez/breez-sdk-liquid-flutter/tags) on Pre-Setup if `liquid-sdk-plugin-version` is not supplied to workflow.